### PR TITLE
feat: convert quote basket to floating quote builder window

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-<title>DefCost 1.0.3</title>
+<title>DefCost 1.2.0</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -39,11 +39,36 @@ summary:hover{background:var(--btn);color:#fff}
 .cat-brown summary{background:#f2e6d9}.cat-brown summary:hover{background:#e0cbb9;color:#000}
 .cat-red summary{background:#ffdede}.cat-red summary:hover{background:#ffb7b7;color:#000}
 .cat-yellow summary{background:#fff8d6}.cat-yellow summary:hover{background:#ffea9f;color:#000}
-#basketContainer{position:fixed;bottom:0;left:0;right:0;max-height:40%;background:var(--panel);padding:0 1rem 1rem;box-shadow:0 -2px 5px rgba(0,0,0,.1);z-index:9999;overflow-y:auto;transform:translateZ(0);isolation:isolate;scrollbar-gutter:stable both-edges}
+#qbWindow{position:fixed;top:64px;right:32px;width:min(1100px,90vw);height:min(65vh,80vh);background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:0 24px 80px rgba(0,0,0,.35);display:flex;flex-direction:column;z-index:10000;overflow:hidden}
+#qbWindow.qb-full{top:0;left:0;right:0;bottom:0;width:100vw;height:100vh;border-radius:0}
+#qbTitlebar{display:flex;align-items:center;justify-content:space-between;gap:.5rem;padding:.5rem .75rem;background:var(--header);border-bottom:1px solid var(--border);cursor:move;user-select:none}
+#qbDots{display:flex;gap:.5rem}
+#qbDots button{width:12px;height:12px;border-radius:50%;border:0;cursor:pointer}
+#qbClose{background:#ff5f57}
+#qbMin{background:#ffbd2e}
+#qbZoom{background:#28c840}
+.dark-mode #qbClose,.dark-mode #qbMin,.dark-mode #qbZoom{box-shadow:inset 0 0 0 1px rgba(0,0,0,.2)}
+#qbTitle{flex:1;font-weight:bold}
+#qbActions{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:flex-end}
+#qbActions button{background:var(--btn);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer}
+#qbActions button:hover{background:var(--btnh)}
+#qbBody{flex:1;overflow:auto;scrollbar-gutter:stable both-edges;padding:0 1rem 1rem}
+#qbDockIcon{position:fixed;left:16px;bottom:16px;display:none;border-radius:999px;padding:.5rem .8rem;background:var(--btn);color:#fff;border:none;cursor:pointer;z-index:10001}
+#qbDockIcon:hover{background:var(--btnh)}
+.qb-modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:10002;padding:1rem}
+.qb-modal{background:var(--panel);color:var(--fg);border:1px solid var(--border);border-radius:12px;box-shadow:0 20px 60px rgba(0,0,0,.35);max-width:420px;width:100%;padding:1.25rem;display:flex;flex-direction:column;gap:1rem}
+.qb-modal h4{margin:0;font-size:1.1rem}
+.qb-modal p{margin:0;font-size:.95rem;line-height:1.4}
+.qb-modal-buttons{display:flex;gap:.5rem;justify-content:flex-end;flex-wrap:wrap}
+.qb-modal-buttons button{background:var(--btn);color:#fff;border:none;padding:.4rem .75rem;border-radius:6px;cursor:pointer}
+.qb-modal-buttons button:hover{background:var(--btnh)}
+.qb-modal-buttons .danger{background:#dc3545}
+.qb-modal-buttons .danger:hover{background:#bb2d3b}
+.qb-modal-buttons .neutral{background:var(--header);color:var(--fg)}
+.qb-modal-buttons .neutral:hover{filter:brightness(.95)}
+#basketContainer{display:flex;flex-direction:column;min-height:100%;gap:0}
 #basketHeader{display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem}
 #basketHeader h3{margin:0}
-#basketHeader button{background:var(--btn);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;cursor:pointer}
-#basketHeader button:hover{background:var(--btnh)}
 #sectionTabsBar{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;padding:.35rem .5rem;background:var(--header);border:1px solid var(--border);border-top:0}
 #sectionTabs{display:flex;flex-wrap:wrap;gap:.25rem}
 .section-tab{display:inline-flex;align-items:center;gap:.35rem;padding:.3rem .6rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg);cursor:pointer;transition:.2s}
@@ -90,8 +115,6 @@ summary:hover{background:var(--btn);color:#fff}
 .qty-controls button{padding:.2rem .45rem;line-height:1}
 .section-select{margin-left:.35rem;padding:.2rem .3rem;border:1px solid var(--border);border-radius:4px;background:var(--panel);color:var(--fg);font-size:.85rem}
 .dark-mode .section-select{background:#444;color:#fff;border-color:#666}
-#basketFab{position:fixed;right:16px;bottom:16px;background:var(--btn);color:#fff;border:none;border-radius:999px;padding:.6rem .9rem;box-shadow:0 6px 16px rgba(0,0,0,.2);cursor:pointer;z-index:1200;display:none}
-#basketFab:hover{background:var(--btnh)}
 #basketSticky{position:sticky;top:0;z-index:4;background:var(--panel);box-shadow:0 2px 4px rgba(0,0,0,.06);padding:1rem 0 0;border-top:1px solid var(--border)}
 #basketStickyHead{background:var(--panel)}
 #basketStickyHead table{width:100%;table-layout:fixed;border-collapse:collapse}
@@ -102,70 +125,80 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-<h1>DefCost 1.0.3</h1>
+<h1>DefCost 1.2.0</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="sheetTabs"></div>
 <div id="status" style="margin:.5rem 0;font-size:.9rem"></div>
 <div id="manualLoad" style="display:none;margin:.5rem 0"><label class="search-label">Load workbook:</label><input type="file" id="xlsxPicker" accept=".xlsx"></div>
 <div id="sheetContainer"></div>
-<div id="basketContainer">
-  <div id="basketSticky">
-    <div id="basketHeader">
-      <div style="display:flex;align-items:center;gap:.5rem"><h3>Quote Basket</h3><span id="toast"></span></div>
-      <div>
-        <button id="addCustomBtn">Add custom line</button>
-        <button id="clearBasketBtn">Clear</button>
-        <button id="exportCsvBtn">Export quote CSV</button>
-        <button id="toggleBasketBtn">Hide Basket</button>
+<div id="qbWindow" aria-label="Quote Builder window" role="dialog" aria-modal="false">
+  <div id="qbTitlebar">
+    <div id="qbDots">
+      <button id="qbClose" aria-label="Delete quote" title="Delete quote"></button>
+      <button id="qbMin" aria-label="Minimize" title="Minimize"></button>
+      <button id="qbZoom" aria-label="Full screen" title="Full screen"></button>
+    </div>
+    <div id="qbTitle">Quote Builder</div>
+    <div id="qbActions">
+      <button id="addCustomBtn">Add custom line</button>
+      <button id="addSectionBtn" type="button">+ Section</button>
+      <button id="exportCsvBtn">Export quote CSV</button>
+    </div>
+  </div>
+  <div id="qbBody">
+    <div id="basketContainer">
+      <div id="basketSticky">
+        <div id="basketHeader">
+          <div style="display:flex;align-items:center;gap:.5rem"><h3>Quote Builder</h3><span id="toast"></span></div>
+        </div>
+        <div id="sectionTabsBar">
+          <div id="sectionTabs"></div>
+        </div>
+        <div id="basketStickyHead">
+          <table id="basketHead">
+            <colgroup>
+              <col style="width:36px">
+              <col id="col-item">
+              <col style="width:120px">
+              <col style="width:100px">
+              <col style="width:110px">
+              <col style="width:90px">
+              <col style="width:120px">
+              <col style="width:50px">
+            </colgroup>
+            <thead><tr>
+              <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
+              <th>Price Ex. GST</th>
+              <th>Line Total Ex. GST</th><th>GST</th><th>Line Total</th><th></th>
+            </tr></thead>
+          </table>
+        </div>
+      </div>
+      <div id="basketContent">
+        <table id="basketTable">
+          <colgroup>
+            <col style="width:36px">
+            <col id="col-item">
+            <col style="width:120px">
+            <col style="width:100px">
+            <col style="width:110px">
+            <col style="width:90px">
+            <col style="width:120px">
+            <col style="width:50px">
+          </colgroup>
+          <thead><tr>
+            <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
+            <th>Price Ex. GST</th>
+            <th>Line Total Ex. GST</th><th>GST</th><th>Line Total</th><th></th>
+          </tr></thead>
+          <tbody></tbody><tfoot></tfoot>
+        </table>
+        <div id="grandTotals" style="display:none"></div>
       </div>
     </div>
-    <div id="sectionTabsBar">
-      <div id="sectionTabs"></div>
-      <button id="addSectionBtn" type="button">+ Section</button>
-    </div>
-    <div id="basketStickyHead">
-      <table id="basketHead">
-        <colgroup>
-          <col style="width:36px">
-          <col id="col-item">
-          <col style="width:120px">
-          <col style="width:100px">
-          <col style="width:110px">
-          <col style="width:90px">
-          <col style="width:120px">
-          <col style="width:50px">
-        </colgroup>
-        <thead><tr>
-          <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
-          <th>Price Ex. GST</th>
-          <th>Line Total Ex. GST</th><th>GST</th><th>Line Total</th><th></th>
-        </tr></thead>
-      </table>
-    </div>
-  </div>
-  <div id="basketContent">
-    <table id="basketTable">
-      <colgroup>
-        <col style="width:36px">
-        <col id="col-item">
-        <col style="width:120px">
-        <col style="width:100px">
-        <col style="width:110px">
-        <col style="width:90px">
-        <col style="width:120px">
-        <col style="width:50px">
-      </colgroup>
-      <thead><tr>
-        <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
-        <th>Price Ex. GST</th>
-        <th>Line Total Ex. GST</th><th>GST</th><th>Line Total</th><th></th>
-      </tr></thead>
-      <tbody></tbody><tfoot></tfoot>
-    </table>
-    <div id="grandTotals" style="display:none"></div>
   </div>
 </div>
-<button id="basketFab" aria-label="Open quote basket" title="Open quote basket">Quote (0)</button>
+<button id="qbDockIcon" title="Open Quote Builder" aria-label="Open Quote Builder">Quote</button>
 <script src="xlsx.full.min.js"></script>
 <script>if(!window.XLSX){var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/xlsx@0.20.3/dist/xlsx.full.min.js';s.setAttribute('data-sheetjs','1');document.head.appendChild(s);}</script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
@@ -175,10 +208,24 @@ var ORDER=[["bannister rail","cat-orange"],["stainless steel grabrail","cat-oran
 var META=(function(){var o={};for(var i=0;i<ORDER.length;i++){o[ORDER[i][0]]={idx:i,cls:ORDER[i][1]};}return o;})();
 var FALL=META["uncategorised"];
 var PRICE_EX=["Rate Ex. GST","Price Ex. GST","Price","Price Ex Tax","Price ex GST"];
-var TOAST_MS=3000,GST_RATE=0.10,LS_KEY='defcost_basket_v2';
+var TOAST_MS=3000,GST_RATE=0.10,LS_KEY='defcost_basket_v2',UI_KEY='defcost_qb_ui_v1';
 var wb=null,basket=[],sections=getDefaultSections(),uid=0,sectionSeq=1,activeSectionId=sections[0].id,captureParentId=null;
 var tabs=document.getElementById("sheetTabs"),container=document.getElementById("sheetContainer"),toast=document.getElementById("toast"),sectionTabsEl=document.getElementById("sectionTabs"),grandTotalsEl=document.getElementById("grandTotals");
-var addSectionBtn=document.getElementById("addSectionBtn");
+var qbWindow=document.getElementById('qbWindow'),qbTitlebar=document.getElementById('qbTitlebar'),qbDockIcon=document.getElementById('qbDockIcon'),qbMin=document.getElementById('qbMin'),qbClose=document.getElementById('qbClose'),qbZoom=document.getElementById('qbZoom');
+var addSectionBtn=document.getElementById("addSectionBtn"),qbTitle=document.getElementById('qbTitle');
+var qbState=loadUiState();
+var lastFreeRect=cloneRect(qbState);
+if(!lastFreeRect.w||!lastFreeRect.h){lastFreeRect=cloneRect(defaultUiState());}
+var dragInfo=null,prevUserSelect='';
+applyQBState(true);
+ensureWindowWithinViewport(true);
+if(qbTitlebar){qbTitlebar.addEventListener('mousedown',startDrag);qbTitlebar.addEventListener('touchstart',startDrag,{passive:false});}
+if(qbMin){qbMin.addEventListener('click',function(){setMinimized(true);});}
+if(qbDockIcon){qbDockIcon.addEventListener('click',restoreFromDock);}
+if(qbClose){qbClose.addEventListener('click',showDeleteDialog);}
+if(qbZoom){qbZoom.addEventListener('click',toggleFull);}
+window.addEventListener('resize',function(){ensureWindowWithinViewport();});
+document.addEventListener('keydown',function(ev){if(ev.key==='Escape'||ev.key==='Esc'){if(qbState.full){toggleFull();}else if(!qbState.minimized){setMinimized(true);}}});
 function active(n){if(!tabs)return;var kids=tabs.children;for(var i=0;i<kids.length;i++){var b=kids[i];b.classList.toggle('active',b.dataset&&b.dataset.sheet===n);}}
 function saveBasket(){
   try{
@@ -203,8 +250,27 @@ function loadBasket(){
   normalizeBasketItems();
   renderBasket();
 }
-function showToast(msg,undo){var el=toast;el.textContent=msg;el.classList.add("show");if(undo){el.style.cursor="pointer";el.onclick=function(){undo();el.classList.remove("show");};}else{el.style.cursor="default";el.onclick=null;}setTimeout(function(){el.classList.remove("show");},TOAST_MS);} 
-function escapeHtml(s){s=String(s==null?'':s);return s.replace(/[&<>"']/g,function(m){switch(m){case'&':return'&amp;';case'<':return'&lt;';case'>':return'&gt;';case'"':return'&quot;';default:return'&#39;';}});} 
+function showToast(msg,undo){var el=toast;el.textContent=msg;el.classList.add("show");if(undo){el.style.cursor="pointer";el.onclick=function(){undo();el.classList.remove("show");};}else{el.style.cursor="default";el.onclick=null;}setTimeout(function(){el.classList.remove("show");},TOAST_MS);}
+function cloneRect(state){if(!state||typeof state!=='object')return{x:0,y:0,w:0,h:0};return{x:isFinite(state.x)?+state.x:0,y:isFinite(state.y)?+state.y:0,w:isFinite(state.w)?+state.w:0,h:isFinite(state.h)?+state.h:0};}
+function defaultUiState(){var winW=window.innerWidth||1200;var winH=window.innerHeight||800;var width=Math.min(1100,Math.max(360,Math.round((winW||0)*0.9)||600));if(!isFinite(width)||width<=0)width=800;if(width>winW&&winW>0)width=winW;var height=Math.round((winH||0)*0.65)||520;height=Math.min(height,Math.round((winH||0)*0.8)||height);if(!isFinite(height)||height<=0)height=Math.min(winH||600,600);if(height>winH&&winH>0)height=winH;var maxX=Math.max(0,(winW||width)-width-32);var y=Math.min(64,Math.max(0,(winH||height)-height));return{x:maxX,y:y,w:width,h:height,minimized:false,full:false};}
+function normalizeUiState(state){var base=defaultUiState();state=state&&typeof state==='object'?state:{};var winW=window.innerWidth||base.w;var winH=window.innerHeight||base.h;var width=parseFloat(state.w);if(!isFinite(width)||width<320)width=base.w;width=Math.min(Math.max(320,width),winW||width);var height=parseFloat(state.h);if(!isFinite(height)||height<280)height=base.h;height=Math.min(Math.max(280,height),winH||height);var x=parseFloat(state.x);if(!isFinite(x))x=Math.max(0,(winW||width)-width-32);var y=parseFloat(state.y);if(!isFinite(y))y=base.y;var maxX=Math.max(0,(winW||width)-width);var maxY=Math.max(0,(winH||height)-height);x=Math.min(Math.max(0,x),maxX);y=Math.min(Math.max(0,y),maxY);return{x:x,y:y,w:width,h:height,minimized:!!state.minimized,full:!!state.full};}
+function loadUiState(){var stored=null;try{var raw=localStorage.getItem(UI_KEY);if(raw){var parsed=JSON.parse(raw);if(parsed&&typeof parsed==='object'){stored=parsed;}}}catch(e){}return normalizeUiState(stored);}
+function rememberCurrentRect(){if(qbState&&qbState.full)return;lastFreeRect=cloneRect(qbState);}
+function assignRect(rect){if(!rect)return;if(isFinite(rect.x))qbState.x=rect.x;if(isFinite(rect.y))qbState.y=rect.y;if(isFinite(rect.w)&&rect.w>0)qbState.w=rect.w;if(isFinite(rect.h)&&rect.h>0)qbState.h=rect.h;}
+function applyQBState(skipSave){if(!qbWindow)return;var minimized=!!qbState.minimized;var full=!!qbState.full;if(full){qbWindow.classList.add('qb-full');qbWindow.style.top='';qbWindow.style.left='';qbWindow.style.right='';qbWindow.style.bottom='';qbWindow.style.width='';qbWindow.style.height='';}else{qbWindow.classList.remove('qb-full');qbWindow.style.width=qbState.w?qbState.w+'px':'';qbWindow.style.height=qbState.h?qbState.h+'px':'';qbWindow.style.top=(isFinite(qbState.y)?qbState.y:0)+'px';qbWindow.style.left=(isFinite(qbState.x)?qbState.x:0)+'px';qbWindow.style.right='auto';qbWindow.style.bottom='auto';}
+  if(minimized){qbWindow.style.display='none';qbWindow.setAttribute('aria-hidden','true');if(qbDockIcon){qbDockIcon.style.display='inline-flex';}}else{qbWindow.style.display='flex';qbWindow.setAttribute('aria-hidden','false');if(qbDockIcon){qbDockIcon.style.display='none';}}
+  if(!skipSave)saveUiState();}
+function ensureWindowWithinViewport(skipSave){if(!qbWindow||qbState.full||qbState.minimized)return;var winW=window.innerWidth||qbState.w||800;var winH=window.innerHeight||qbState.h||600;qbState.w=Math.min(Math.max(320,qbState.w||320),winW);qbState.h=Math.min(Math.max(280,qbState.h||280),winH);var maxX=Math.max(0,winW-qbState.w);var maxY=Math.max(0,winH-qbState.h);if(qbState.x>maxX)qbState.x=maxX;if(qbState.y>maxY)qbState.y=maxY;applyQBState(true);if(!skipSave)saveUiState();}
+function saveUiState(){if(!qbState)return;var payload={x:Math.round(isFinite(qbState.x)?qbState.x:0),y:Math.round(isFinite(qbState.y)?qbState.y:0),w:Math.round(isFinite(qbState.w)?qbState.w:0),h:Math.round(isFinite(qbState.h)?qbState.h:0),minimized:!!qbState.minimized,full:!!qbState.full};try{localStorage.setItem(UI_KEY,JSON.stringify(payload));}catch(e){}}
+function setMinimized(minimize){if(minimize){if(qbState.full){qbState.full=false;if(lastFreeRect&&lastFreeRect.w){assignRect(lastFreeRect);} }else{rememberCurrentRect();}qbState.minimized=true;}else{qbState.minimized=false;}applyQBState();}
+function restoreFromDock(){setMinimized(false);}
+function toggleFull(){if(qbState.full){qbState.full=false;if(lastFreeRect&&lastFreeRect.w){assignRect(lastFreeRect);}applyQBState();saveUiState();return;}rememberCurrentRect();qbState.full=true;qbState.minimized=false;applyQBState();saveUiState();}
+function getPointerCoords(ev){if(ev.touches&&ev.touches.length){return{clientX:ev.touches[0].clientX,clientY:ev.touches[0].clientY};}if(ev.changedTouches&&ev.changedTouches.length){return{clientX:ev.changedTouches[0].clientX,clientY:ev.changedTouches[0].clientY};}return{clientX:ev.clientX,clientY:ev.clientY};}
+function isDragHandleTarget(target){if(!target)return true;var node=target;if(node.closest){if(node.closest('#qbDots')||node.closest('#qbActions'))return false;}while(node&&node!==qbTitlebar){var tag=node.tagName;if(tag&&(tag==='BUTTON'||tag==='INPUT'||tag==='TEXTAREA'||tag==='SELECT'||tag==='LABEL'))return false;node=node.parentNode;}return true;}
+function startDrag(ev){if(!qbWindow||qbState.full||qbState.minimized)return;var target=ev.target||ev.srcElement;if(!isDragHandleTarget(target))return;var coords=getPointerCoords(ev);if(typeof coords.clientX==='undefined')return;if(ev.cancelable)ev.preventDefault();rememberCurrentRect();var rect=qbWindow.getBoundingClientRect();dragInfo={offsetX:coords.clientX-rect.left,offsetY:coords.clientY-rect.top,width:rect.width,height:rect.height};prevUserSelect=document.body.style.userSelect;document.body.style.userSelect='none';document.addEventListener('mousemove',handleDragMove);document.addEventListener('mouseup',endDrag);document.addEventListener('touchmove',handleDragMove,{passive:false});document.addEventListener('touchend',endDrag);document.addEventListener('touchcancel',endDrag);}
+function handleDragMove(ev){if(!dragInfo)return;var coords=getPointerCoords(ev);if(typeof coords.clientX==='undefined')return;if(ev.cancelable)ev.preventDefault();var winW=window.innerWidth||dragInfo.width||800;var winH=window.innerHeight||dragInfo.height||600;var width=Math.min(Math.max(320,dragInfo.width||320),winW);var height=Math.min(Math.max(280,dragInfo.height||280),winH);var x=coords.clientX-dragInfo.offsetX;var y=coords.clientY-dragInfo.offsetY;var maxX=Math.max(0,winW-width);var maxY=Math.max(0,winH-height);if(x<0)x=0;if(y<0)y=0;if(x>maxX)x=maxX;if(y>maxY)y=maxY;qbWindow.classList.remove('qb-full');qbState.full=false;qbState.minimized=false;qbState.x=x;qbState.y=y;qbState.w=width;qbState.h=height;qbWindow.style.left=x+'px';qbWindow.style.top=y+'px';qbWindow.style.right='auto';qbWindow.style.bottom='auto';qbWindow.style.display='flex';}
+function endDrag(){if(!dragInfo)return;document.body.style.userSelect=prevUserSelect||'';document.removeEventListener('mousemove',handleDragMove);document.removeEventListener('mouseup',endDrag);document.removeEventListener('touchmove',handleDragMove);document.removeEventListener('touchend',endDrag);document.removeEventListener('touchcancel',endDrag);dragInfo=null;saveUiState();rememberCurrentRect();}
+function escapeHtml(s){s=String(s==null?'':s);return s.replace(/[&<>"']/g,function(m){switch(m){case'&':return'&amp;';case'<':return'&lt;';case'>':return'&gt;';case'"':return'&quot;';default:return'&#39;';}});}
 function getDefaultSections(){return [{id:1,name:'Section 1'}];}
 function ensureSectionState(){
   if(!Array.isArray(sections)||!sections.length){
@@ -367,18 +433,9 @@ if(bFootEl){
     navigator.clipboard.writeText(text).then(function(){ td.classList.add('copied-cell'); void td.offsetWidth; setTimeout(function(){ td.classList.remove('copied-cell'); },150); }).catch(function(){});
   });
 }
-document.getElementById('toggleBasketBtn').onclick=function(){
-  var cont=document.getElementById('basketContainer');
-  var fab=document.getElementById('basketFab');
-  cont.style.display='none';
-  if(fab){ fab.style.display='inline-block'; fab.textContent='Quote ('+basket.length+')'; }
-};
-var basketFab=document.getElementById('basketFab');
-if(basketFab){ basketFab.onclick=function(){ var cont=document.getElementById('basketContainer'); cont.style.display=basket.length?'block':'none'; basketFab.style.display='none'; }; }
 if(addSectionBtn){addSectionBtn.addEventListener('click',function(){ensureSectionState();var suggestion='Section '+(sectionSeq+1);var name=prompt('Section name',suggestion);if(name===null)return;name=name.trim();if(!name){showToast('Section name is required');return;}var newId=sectionSeq+1;sections.push({id:newId,name:name});sectionSeq=newId;activeSectionId=newId;captureParentId=null;renderBasket();showToast('Section added');});}
-var addCustomBtn=document.getElementById('addCustomBtn');var clearBasketBtn=document.getElementById('clearBasketBtn');
-if(addCustomBtn){addCustomBtn.addEventListener('click',function(){var nl;if(captureParentId){nl={id:++uid,pid:captureParentId,kind:'sub',item:'Sub item',qty:1,ex:0};}else{nl={id:++uid,pid:null,kind:'line',collapsed:false,sectionId:activeSectionId,item:'Custom item',qty:1,ex:0};}basket.push(nl);renderBasket();try{var rows=bBody.querySelectorAll('tr.main-row');if(rows.length){var last=rows[rows.length-1].querySelector('.item-input');if(last)last.focus();}}catch(_){}});} 
-if(clearBasketBtn){clearBasketBtn.addEventListener('click',function(){if(!basket.length)return;basket=[];captureParentId=null;renderBasket();showToast('Basket cleared');});}
+var addCustomBtn=document.getElementById('addCustomBtn');
+if(addCustomBtn){addCustomBtn.addEventListener('click',function(){var nl;if(captureParentId){nl={id:++uid,pid:captureParentId,kind:'sub',item:'Sub item',qty:1,ex:0};}else{nl={id:++uid,pid:null,kind:'line',collapsed:false,sectionId:activeSectionId,item:'Custom item',qty:1,ex:0};}basket.push(nl);renderBasket();try{var rows=bBody.querySelectorAll('tr.main-row');if(rows.length){var last=rows[rows.length-1].querySelector('.item-input');if(last)last.focus();}}catch(_){}});}
 function updateBasketHeaderOffset(){
   var cont=document.getElementById('basketContainer');
   var sticky=document.getElementById('basketSticky');
@@ -416,24 +473,18 @@ function addItem(row,header){
 function renderBasket(){
   ensureSectionState();
   var cont=document.getElementById('basketContainer');
-  var fab=document.getElementById('basketFab');
   if(!cont||!bBody||!bFoot){ saveBasket(); return; }
+  if(qbDockIcon){ qbDockIcon.textContent=basket.length?'Quote ('+basket.length+')':'Quote'; }
+  if(qbTitle){ qbTitle.textContent=basket.length?'Quote Builder ('+basket.length+')':'Quote Builder'; }
+  renderSectionTabs();
   if(!basket.length){
-    cont.style.display='none';
-    if(fab){ fab.style.display='none'; fab.textContent='Quote (0)'; }
     bBody.innerHTML='';
     bFoot.innerHTML='';
-    if(sectionTabsEl) sectionTabsEl.innerHTML='';
     if(grandTotalsEl){ grandTotalsEl.style.display='none'; grandTotalsEl.innerHTML=''; }
     saveBasket();
     updateBasketHeaderOffset();
     return;
   }
-  if(fab){
-    fab.textContent='Quote ('+basket.length+')';
-    if(cont.style.display==='none'){ fab.style.display='inline-block'; } else { fab.style.display='none'; }
-  }
-  renderSectionTabs();
   var fallback=sections[0]?sections[0].id:1;
   if(!sections.some(function(sec){return sec.id===activeSectionId;})){
     activeSectionId=fallback;
@@ -622,30 +673,66 @@ function renderBasket(){
   saveBasket();
   updateBasketHeaderOffset();
 }
-var exportBtn=document.getElementById("exportCsvBtn");
-if(exportBtn){
-  exportBtn.onclick=function(){
-    if(!basket.length) return;
-    var esc=function(v){return '"'+String(v).replace(/"/g,'""')+'"';};
-    var report=buildReportModel(basket,sections);
-    var lines=[["Section","Item","Quantity","Price Ex. GST","Line Ex","GST","Line Total"]];
-    for(var si=0;si<report.sections.length;si++){
-      var sec=report.sections[si];
-      for(var gi=0;gi<sec.items.length;gi++){
-        var grp=sec.items[gi];
-        var p=grp.parent; var le=isNaN(p.ex)?0:(p.qty||1)*p.ex; var gstAmt=le*GST_RATE; var li=le+gstAmt;
-        lines.push([sec.name,(p.item||''),(p.qty||1),isNaN(p.ex)?"N/A":Number(p.ex).toFixed(2),isNaN(p.ex)?"N/A":le.toFixed(2),isNaN(p.ex)?"N/A":gstAmt.toFixed(2),isNaN(p.ex)?"N/A":li.toFixed(2)]);
-        var subs=grp.subs||[];
-        for(var sj=0;sj<subs.length;sj++){
-          var s=subs[sj]; var sle=isNaN(s.ex)?0:(s.qty||1)*s.ex; var sg=sle*GST_RATE; var st=sle+sg;
-          lines.push([sec.name,' - '+(s.item||''),(s.qty||1),isNaN(s.ex)?"N/A":Number(s.ex).toFixed(2),isNaN(s.ex)?"N/A":sle.toFixed(2),isNaN(s.ex)?"N/A":sg.toFixed(2),isNaN(s.ex)?"N/A":st.toFixed(2)]);
-        }
+function exportBasketToCsv(opts){
+  if(!basket.length) return false;
+  var esc=function(v){return '"'+String(v).replace(/"/g,'""')+'"';};
+  var report=buildReportModel(basket,sections);
+  var lines=[["Section","Item","Quantity","Price Ex. GST","Line Ex","GST","Line Total"]];
+  for(var si=0;si<report.sections.length;si++){
+    var sec=report.sections[si];
+    for(var gi=0;gi<sec.items.length;gi++){
+      var grp=sec.items[gi];
+      var p=grp.parent; var le=isNaN(p.ex)?0:(p.qty||1)*p.ex; var gstAmt=le*GST_RATE; var li=le+gstAmt;
+      lines.push([sec.name,(p.item||''),(p.qty||1),isNaN(p.ex)?"N/A":Number(p.ex).toFixed(2),isNaN(p.ex)?"N/A":le.toFixed(2),isNaN(p.ex)?"N/A":gstAmt.toFixed(2),isNaN(p.ex)?"N/A":li.toFixed(2)]);
+      var subs=grp.subs||[];
+      for(var sj=0;sj<subs.length;sj++){
+        var s=subs[sj]; var sle=isNaN(s.ex)?0:(s.qty||1)*s.ex; var sg=sle*GST_RATE; var st=sle+sg;
+        lines.push([sec.name,' - '+(s.item||''),(s.qty||1),isNaN(s.ex)?"N/A":Number(s.ex).toFixed(2),isNaN(s.ex)?"N/A":sle.toFixed(2),isNaN(s.ex)?"N/A":sg.toFixed(2),isNaN(s.ex)?"N/A":st.toFixed(2)]);
       }
     }
-    lines.push(["Totals","","","",report.grandEx.toFixed(2),report.grandGst.toFixed(2),report.grandTotal.toFixed(2)]);
-    var out=[]; for(var r=0;r<lines.length;r++){ var row=lines[r]; for(var c=0;c<row.length;c++){ row[c]=esc(row[c]); } out.push(row.join(',')); }
-    var csv=out.join("\n"); var blob=new Blob([csv],{type:"text/csv"}); var a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="quote_basket.csv"; document.body.appendChild(a); a.click(); document.body.removeChild(a);
-  };
+  }
+  lines.push(["Totals","","","",report.grandEx.toFixed(2),report.grandGst.toFixed(2),report.grandTotal.toFixed(2)]);
+  var out=[]; for(var r=0;r<lines.length;r++){ var row=lines[r]; for(var c=0;c<row.length;c++){ row[c]=esc(row[c]); } out.push(row.join(',')); }
+  var csv=out.join("\n"); var blob=new Blob([csv],{type:"text/csv"}); var a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="quote_basket.csv"; document.body.appendChild(a); a.click(); document.body.removeChild(a);
+  if(!(opts&&opts.silent)){ showToast('Quote CSV exported'); }
+  return true;
+}
+function resetQuote(toastMessage){
+  basket=[];
+  captureParentId=null;
+  sections=getDefaultSections();
+  ensureSectionState();
+  var first=sections[0];
+  activeSectionId=first?first.id:1;
+  sectionSeq=first?first.id:sectionSeq;
+  renderBasket();
+  if(toastMessage){ showToast(toastMessage); }
+}
+function showDeleteDialog(){
+  if(document.querySelector('.qb-modal-backdrop')) return;
+  var overlay=document.createElement('div'); overlay.className='qb-modal-backdrop';
+  var modal=document.createElement('div'); modal.className='qb-modal'; modal.setAttribute('role','dialog'); modal.setAttribute('aria-modal','true'); modal.setAttribute('aria-labelledby','qbDeleteTitle');
+  var title=document.createElement('h4'); title.id='qbDeleteTitle'; title.textContent='Delete quote?';
+  var message=document.createElement('p'); message.textContent='Would you like to export the quote to CSV before deleting?';
+  var buttons=document.createElement('div'); buttons.className='qb-modal-buttons';
+  var saveBtn=document.createElement('button'); saveBtn.type='button'; saveBtn.textContent='Save CSV';
+  var deleteBtn=document.createElement('button'); deleteBtn.type='button'; deleteBtn.textContent='Delete'; deleteBtn.classList.add('danger');
+  var cancelBtn=document.createElement('button'); cancelBtn.type='button'; cancelBtn.textContent='Cancel'; cancelBtn.classList.add('neutral');
+  buttons.appendChild(saveBtn); buttons.appendChild(deleteBtn); buttons.appendChild(cancelBtn);
+  modal.appendChild(title); modal.appendChild(message); modal.appendChild(buttons); overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  function closeDialog(){ document.removeEventListener('keydown',handleKey,true); if(overlay&&overlay.parentNode){ overlay.parentNode.removeChild(overlay); } if(qbClose){ try{qbClose.focus();}catch(e){} } }
+  function handleKey(ev){ if(ev.key==='Escape'||ev.key==='Esc'){ ev.preventDefault(); ev.stopPropagation(); closeDialog(); } }
+  document.addEventListener('keydown',handleKey,true);
+  overlay.addEventListener('click',function(ev){ if(ev.target===overlay){ closeDialog(); }});
+  cancelBtn.addEventListener('click',closeDialog);
+  saveBtn.addEventListener('click',function(){ var exported=exportBasketToCsv({silent:true}); resetQuote(exported?'Quote exported and deleted':'Quote deleted'); closeDialog(); });
+  deleteBtn.addEventListener('click',function(){ resetQuote('Quote deleted'); closeDialog(); });
+  setTimeout(function(){ try{saveBtn.focus();}catch(e){} },0);
+}
+var exportBtn=document.getElementById("exportCsvBtn");
+if(exportBtn){
+  exportBtn.onclick=function(){ exportBasketToCsv(); };
 }
 window.__wd_main_ok__=true;
 })();


### PR DESCRIPTION
## Summary
- replace the bottom quote basket with a draggable floating Quote Builder window styled with macOS controls
- persist window UI state, add dock/minimize/zoom actions, and provide a delete confirmation dialog that can export before clearing
- update quote builder controls, CSV export hooks, and bump the app version to 1.2.0

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5dbc313fc8327ba95239e4478da03