### PR TITLE
Update quote builder layout and totals

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,12 +119,21 @@ summary:hover{background:var(--btn);color:#fff}
 #basketTable th:nth-child(1),#basketTable td:nth-child(1){width:36px}
 #basketTable th:nth-child(3),#basketTable td:nth-child(3){width:140px}
 #basketTable th:nth-child(4),#basketTable td:nth-child(4){width:120px}
-#basketTable th:nth-child(5),#basketTable td:nth-child(5){width:120px}
-#basketTable th:nth-child(6),#basketTable td:nth-child(6){width:100px}
-#basketTable th:nth-child(7),#basketTable td:nth-child(7){width:120px}
-#basketTable th:nth-child(8),#basketTable td:nth-child(8){width:50px}
-#grandTotals{margin-top:.6rem;padding:.5rem .75rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);display:flex;justify-content:flex-end;gap:1.5rem;font-weight:bold}
-.grand-total-label{opacity:.8}
+#basketTable th:nth-child(5),#basketTable td:nth-child(5){width:150px}
+#basketTable th:nth-child(6),#basketTable td:nth-child(6){width:50px}
+#basketTable col#col-item,#basketHead col#col-item{width:auto}
+#grandTotals{margin-top:.6rem;padding:.5rem .75rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);display:none;font-weight:bold}
+.grand-totals-table{width:100%;border-collapse:collapse}
+.grand-totals-table th,.grand-totals-table td{padding:.4rem .5rem;border-bottom:1px solid var(--border);text-align:left;font-weight:normal}
+.grand-totals-table tr:last-child th,.grand-totals-table tr:last-child td{border-bottom:0}
+.grand-totals-table th{font-weight:bold;white-space:nowrap}
+.grand-totals-table .totals-value{text-align:right;font-variant-numeric:tabular-nums}
+.grand-totals-table .totals-note{font-size:.9rem;opacity:.75}
+.grand-totals-input{display:flex;align-items:center;gap:.35rem}
+.grand-totals-input input{width:100%;padding:.35rem .45rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg)}
+.grand-totals-input span{opacity:.75}
+.grand-totals-empty{opacity:.8}
+.grand-totals-empty .grand-totals-input input{cursor:not-allowed;opacity:.6}
 .qty-controls{display:flex;align-items:center;gap:.25rem}
 .qty-controls button{padding:.2rem .45rem;line-height:1}
 .section-select{margin-left:.35rem;padding:.2rem .3rem;border:1px solid var(--border);border-radius:4px;background:var(--panel);color:var(--fg);font-size:.85rem}
@@ -134,6 +143,7 @@ summary:hover{background:var(--btn);color:#fff}
 #basketStickyHead table{width:100%;table-layout:fixed;border-collapse:collapse}
 #basketStickyHead thead th{background:var(--header);border:1px solid var(--border);padding:.28rem;text-align:center}
 #basketTable thead{display:none}
+#basketTable tfoot .section-total-cell{text-align:right;font-weight:bold}
 input[type=number]::-webkit-outer-spin-button,input[type=number]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
 input[type=number]{-moz-appearance:textfield}
 </style>
@@ -165,16 +175,14 @@ input[type=number]{-moz-appearance:textfield}
             <col style="width:36px">
             <col id="col-item">
             <col style="width:120px">
-            <col style="width:100px">
             <col style="width:110px">
-            <col style="width:90px">
-            <col style="width:120px">
+            <col style="width:140px">
             <col style="width:50px">
           </colgroup>
           <thead><tr>
             <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
-            <th>Price Ex. GST</th>
-            <th>Line Total Ex. GST</th><th>GST</th><th>Line Total</th><th></th>
+            <th>Price</th>
+            <th>Line Total</th><th></th>
           </tr></thead>
         </table>
       </div>
@@ -185,16 +193,14 @@ input[type=number]{-moz-appearance:textfield}
           <col style="width:36px">
           <col id="col-item">
           <col style="width:120px">
-          <col style="width:100px">
           <col style="width:110px">
-          <col style="width:90px">
-          <col style="width:120px">
+          <col style="width:140px">
           <col style="width:50px">
         </colgroup>
         <thead><tr>
           <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
-          <th>Price Ex. GST</th>
-          <th>Line Total Ex. GST</th><th>GST</th><th>Line Total</th><th></th>
+          <th>Price</th>
+          <th>Line Total</th><th></th>
         </tr></thead>
         <tbody></tbody><tfoot></tfoot>
       </table>
@@ -232,6 +238,7 @@ var PRICE_EX=["Rate Ex. GST","Price Ex. GST","Price","Price Ex Tax","Price ex GS
 var TOAST_MS=3000,GST_RATE=0.10,LS_KEY='defcost_basket_v2',UI_KEY='defcost_qb_ui_v1';
 var wb=null,basket=[],sections=getDefaultSections(),uid=0,sectionSeq=1,activeSectionId=sections[0].id,captureParentId=null;
 var tabs=document.getElementById("sheetTabs"),container=document.getElementById("sheetContainer"),toast=document.getElementById("toast"),sectionTabsEl=document.getElementById("sectionTabs"),grandTotalsEl=document.getElementById("grandTotals");
+var discountPercent=0,currentGrandTotal=0,lastBaseTotal=0,grandTotalsUi=null,latestReport=null;
 var qbWindow=document.getElementById('catalogWindow'),qbTitlebar=document.getElementById('catalogTitlebar'),qbDockIcon=document.getElementById('catalogDockIcon'),qbMin=document.getElementById('catalogMin'),qbClose=document.getElementById('catalogClose'),qbZoom=document.getElementById('catalogZoom'),qbResizeHandle=document.getElementById('catalogResizeHandle');
 var addSectionBtn=document.getElementById("addSectionBtn"),qbTitle=document.getElementById('qbTitle'),clearQuoteBtn=document.getElementById('clearQuoteBtn');
 var qbState=loadUiState();
@@ -262,7 +269,8 @@ window.addEventListener('resize',function(){ensureWindowWithinViewport();});
 function active(n){if(!tabs)return;var kids=tabs.children;for(var i=0;i<kids.length;i++){var b=kids[i];b.classList.toggle('active',b.dataset&&b.dataset.sheet===n);}}
 function saveBasket(){
   try{
-    localStorage.setItem(LS_KEY,JSON.stringify({items:basket,sections:sections,activeSectionId:activeSectionId}));
+    var payload={items:basket,sections:sections,activeSectionId:activeSectionId,discountPercent:isFinite(discountPercent)?discountPercent:0};
+    localStorage.setItem(LS_KEY,JSON.stringify(payload));
   }catch(e){}
 }
 function loadBasket(){
@@ -276,9 +284,12 @@ function loadBasket(){
         basket=Array.isArray(data.items)?data.items:[];
         if(Array.isArray(data.sections)&&data.sections.length){sections=data.sections;}
         if(data.activeSectionId){activeSectionId=data.activeSectionId;}
+        if(typeof data.discountPercent!=='undefined'&&isFinite(data.discountPercent)){discountPercent=+data.discountPercent;}
       }
     }
   }catch(e){}
+  currentGrandTotal=0;
+  lastBaseTotal=0;
   ensureSectionState();
   normalizeBasketItems();
   renderBasket();
@@ -376,6 +387,64 @@ function normalizeBasketItems(){
   }
 }
 function buildReportModel(basket,sections){sections=(sections&&sections.length)?sections:getDefaultSections();var sectionsById={};for(var i=0;i<sections.length;i++){sectionsById[sections[i].id]=sections[i];}var childMap={};for(var i2=0;i2<basket.length;i2++){var it=basket[i2];if(it&&it.pid){(childMap[it.pid]||(childMap[it.pid]=[])).push(it);}}var secMap={};function ensureSec(id){if(!secMap[id]){var name=sectionsById[id]?sectionsById[id].name:('Section '+id);secMap[id]={id:id,name:name,items:[],subtotalEx:0,subtotalGst:0,subtotalTotal:0};}return secMap[id];}function addAmounts(obj,qty,ex){var le=isNaN(ex)?0:(qty||1)*ex;var gst=le*GST_RATE;obj.subtotalEx+=le;obj.subtotalGst+=gst;obj.subtotalTotal+=le+gst;}for(var i3=0;i3<basket.length;i3++){var it2=basket[i3];if(!it2||it2.pid)continue;var sid=it2.sectionId||sections[0].id;var sec=ensureSec(sid);var subs=childMap[it2.id]||[];sec.items.push({parent:it2,subs:subs});addAmounts(sec,it2.qty,it2.ex);for(var k=0;k<subs.length;k++){addAmounts(sec,subs[k].qty,subs[k].ex);}}var orderedSections=[];var seenSections={};for(var j=0;j<sections.length;j++){var entry=ensureSec(sections[j].id);orderedSections.push(entry);seenSections[entry.id]=true;}for(var id in secMap){if(secMap.hasOwnProperty(id)&&!seenSections[id]){orderedSections.push(secMap[id]);}}if(!orderedSections.length){var base=sections[0];orderedSections.push({id:base.id,name:base.name,items:[],subtotalEx:0,subtotalGst:0,subtotalTotal:0});}var grandEx=0,grandGst=0,grandTotal=0;for(var s=0;s<orderedSections.length;s++){grandEx+=orderedSections[s].subtotalEx;grandGst+=orderedSections[s].subtotalGst;grandTotal+=orderedSections[s].subtotalTotal;}return{sections:orderedSections,grandEx:grandEx,grandGst:grandGst,grandTotal:grandTotal};}
+function roundCurrency(val){if(!isFinite(val))return 0;return Math.round(val*100)/100;}
+function formatCurrency(val){return roundCurrency(isFinite(val)?val:0).toFixed(2);}
+function formatPercent(val){return roundCurrency(isFinite(val)?val:0).toFixed(2);}
+function recalcGrandTotal(base,discount){var b=isFinite(base)?base:0;var d=isFinite(discount)?discount:0;var computed=b*(1-d/100);if(!isFinite(computed))computed=0;return roundCurrency(computed<0?0:computed);}
+function calculateGst(amount){var base=isFinite(amount)?amount:0;return roundCurrency(base*GST_RATE);}
+function ensureGrandTotalsUi(){if(!grandTotalsEl||grandTotalsUi)return;if(!grandTotalsEl)return;grandTotalsEl.innerHTML='<table class="grand-totals-table"><tbody><tr><th scope="row">Total</th><td class="totals-value" data-role="total-value">0.00</td><td class="totals-note">Non-editable</td></tr><tr><th scope="row">Discount</th><td class="totals-field"><div class="grand-totals-input"><input type="number" step="0.01" inputmode="decimal" aria-label="Discount percentage" data-role="discount-input"><span>%</span></div></td><td class="totals-note">User can input a percentage</td></tr><tr><th scope="row">Grand Total</th><td class="totals-field"><div class="grand-totals-input"><input type="number" min="0" step="0.01" inputmode="decimal" aria-label="Grand total after discount" data-role="grand-total-input"></div></td><td class="totals-note">Editable text box (Displays total after discount)</td></tr><tr><th scope="row">GST</th><td class="totals-value" data-role="gst-value">0.00</td><td class="totals-note">Auto-calculated (10% of Grand Total). Non-editable</td></tr><tr><th scope="row">Grand Total (Incl. GST)</th><td class="totals-value" data-role="grand-incl-value">0.00</td><td class="totals-note">Auto-calculated (Grand Total + GST). Non-editable</td></tr></tbody></table>';
+  var discountInput=grandTotalsEl.querySelector('[data-role="discount-input"]');
+  var grandTotalInput=grandTotalsEl.querySelector('[data-role="grand-total-input"]');
+  grandTotalsUi={container:grandTotalsEl,totalValue:grandTotalsEl.querySelector('[data-role="total-value"]'),discountInput:discountInput,grandTotalInput:grandTotalInput,gstValue:grandTotalsEl.querySelector('[data-role="gst-value"]'),grandInclValue:grandTotalsEl.querySelector('[data-role="grand-incl-value"]')};
+  if(discountInput){discountInput.addEventListener('input',handleDiscountChange);}
+  if(grandTotalInput){grandTotalInput.addEventListener('input',handleGrandTotalChange);}
+}
+function handleDiscountChange(){if(!grandTotalsUi)return;var base=latestReport&&isFinite(latestReport.grandEx)?latestReport.grandEx:0;var raw=parseFloat(grandTotalsUi.discountInput.value);if(!isFinite(raw))raw=0;discountPercent=raw;currentGrandTotal=recalcGrandTotal(base,discountPercent);lastBaseTotal=base;updateGrandTotals(latestReport,{preserveGrandTotal:true});saveBasket();}
+function handleGrandTotalChange(){if(!grandTotalsUi)return;var base=latestReport&&isFinite(latestReport.grandEx)?latestReport.grandEx:0;var raw=parseFloat(grandTotalsUi.grandTotalInput.value);if(!isFinite(raw))raw=0;raw=Math.max(0,raw);currentGrandTotal=roundCurrency(raw);if(base>0){discountPercent=(1-currentGrandTotal/(base||1))*100;}else{discountPercent=0;}lastBaseTotal=base;updateGrandTotals(latestReport,{preserveGrandTotal:true});saveBasket();}
+function updateGrandTotals(report,opts){
+  latestReport=report||null;
+  if(!grandTotalsEl)return;
+  ensureGrandTotalsUi();
+  if(!grandTotalsUi)return;
+  var hasItems=basket&&basket.length>0;
+  var base=report&&isFinite(report.grandEx)?report.grandEx:0;
+  if(hasItems){
+    if(!(opts&&opts.preserveGrandTotal)){
+      if(Math.abs(base-lastBaseTotal)>0.005){
+        currentGrandTotal=recalcGrandTotal(base,discountPercent);
+      }
+    }
+    lastBaseTotal=base;
+  }else{
+    lastBaseTotal=0;
+    currentGrandTotal=0;
+  }
+  grandTotalsEl.style.display='block';
+  grandTotalsEl.classList.toggle('grand-totals-empty',!hasItems);
+  if(grandTotalsUi.totalValue)grandTotalsUi.totalValue.textContent=formatCurrency(base);
+  if(grandTotalsUi.discountInput){
+    grandTotalsUi.discountInput.disabled=!hasItems;
+    if(!hasItems&&document.activeElement===grandTotalsUi.discountInput){
+      grandTotalsUi.discountInput.blur();
+    }
+    if(hasItems||document.activeElement!==grandTotalsUi.discountInput){
+      grandTotalsUi.discountInput.value=formatPercent(discountPercent);
+    }
+  }
+  if(grandTotalsUi.grandTotalInput){
+    grandTotalsUi.grandTotalInput.disabled=!hasItems;
+    if(!hasItems&&document.activeElement===grandTotalsUi.grandTotalInput){
+      grandTotalsUi.grandTotalInput.blur();
+    }
+    if(hasItems||document.activeElement!==grandTotalsUi.grandTotalInput){
+      grandTotalsUi.grandTotalInput.value=formatCurrency(currentGrandTotal);
+    }
+  }
+  var gstAmount=hasItems?calculateGst(currentGrandTotal):0;
+  var incl=hasItems?roundCurrency(currentGrandTotal+gstAmount):0;
+  if(grandTotalsUi.gstValue)grandTotalsUi.gstValue.textContent=formatCurrency(gstAmount);
+  if(grandTotalsUi.grandInclValue)grandTotalsUi.grandInclValue.textContent=formatCurrency(incl);
+}
 function getSectionNameById(id){
   for(var i=0;i<sections.length;i++){
     if(sections[i].id===id) return sections[i].name;
@@ -530,7 +599,7 @@ function renderBasket(){
   if(!basket.length){
     bBody.innerHTML='';
     bFoot.innerHTML='';
-    if(grandTotalsEl){ grandTotalsEl.style.display='none'; grandTotalsEl.innerHTML=''; }
+    if(grandTotalsEl){ updateGrandTotals(null,{preserveGrandTotal:true}); }
     saveBasket();
     updateBasketHeaderOffset();
     return;
@@ -589,10 +658,8 @@ function renderBasket(){
     exInput.onchange=function(){ var v=parseFloat(exInput.value); b.ex=isFinite(v)?v:NaN; renderBasket(); };
     tdEx.appendChild(exInput); tr.appendChild(tdEx);
     var le=isNaN(b.ex)?0:(b.qty||1)*b.ex; var gstAmt=le*GST_RATE; var li=le+gstAmt;
-    var tdLe=document.createElement('td'); tdLe.textContent=isNaN(b.ex)?'N/A':le.toFixed(2);
-    var tdG=document.createElement('td'); tdG.textContent=isNaN(b.ex)?'N/A':gstAmt.toFixed(2);
     var tdLi=document.createElement('td'); tdLi.textContent=isNaN(b.ex)?'N/A':li.toFixed(2);
-    tr.appendChild(tdLe); tr.appendChild(tdG); tr.appendChild(tdLi);
+    tr.appendChild(tdLi);
     var tdRem=document.createElement('td'); var x=document.createElement('span'); x.className='remove-btn'; x.textContent='X';
     x.onclick=function(){ var id=b.id; var nb=[]; for(var r=0;r<basket.length;r++){ var it=basket[r]; if(!it) continue; if(it.id===id||it.pid===id) continue; nb.push(it);} basket=nb; if(captureParentId===id) captureParentId=null; renderBasket(); };
     tdRem.appendChild(x); tr.appendChild(tdRem);
@@ -617,12 +684,10 @@ function renderBasket(){
         exInput.onchange=function(){ var v=parseFloat(exInput.value); s.ex=isFinite(v)?v:NaN; renderBasket(); };
         c4.appendChild(exInput); sr.appendChild(c4);
         var sle=isNaN(s.ex)?0:(s.qty||1)*s.ex; var sg=sle*GST_RATE; var st=sle+sg;
-        var c5=document.createElement('td'); c5.textContent=isNaN(s.ex)?'N/A':sle.toFixed(2); sr.appendChild(c5);
-        var c6=document.createElement('td'); c6.textContent=isNaN(s.ex)?'N/A':sg.toFixed(2); sr.appendChild(c6);
-        var c7=document.createElement('td'); c7.textContent=isNaN(s.ex)?'N/A':st.toFixed(2); sr.appendChild(c7);
-        var c8=document.createElement('td'); var rx=document.createElement('span'); rx.className='remove-btn'; rx.textContent='X';
+        var c5=document.createElement('td'); c5.textContent=isNaN(s.ex)?'N/A':st.toFixed(2); sr.appendChild(c5);
+        var c6=document.createElement('td'); var rx=document.createElement('span'); rx.className='remove-btn'; rx.textContent='X';
         rx.onclick=function(){ for(var r=basket.length-1;r>=0;r--){ if(basket[r].id===s.id){ basket.splice(r,1); break; } } renderBasket(); };
-        c8.appendChild(rx); sr.appendChild(c8);
+        c6.appendChild(rx); sr.appendChild(c6);
         bBody.appendChild(sr);
       })(kids[k]);
     }
@@ -652,11 +717,9 @@ function renderBasket(){
       }
     }
   }
-  bFoot.innerHTML='<tr><td colspan="4" style="text-align:right;font-weight:bold">Section Totals ('+escapeHtml(sectionTotals.name)+'):</td><td style="font-weight:bold">'+(sectionTotals.subtotalEx||0).toFixed(2)+'</td><td style="font-weight:bold">'+(sectionTotals.subtotalGst||0).toFixed(2)+'</td><td style="font-weight:bold">'+(sectionTotals.subtotalTotal||0).toFixed(2)+'</td><td></td></tr>';
-  if(grandTotalsEl){
-    grandTotalsEl.style.display='flex';
-    grandTotalsEl.innerHTML='<span class="grand-total-label">Grand Totals:</span><span>Ex. GST '+report.grandEx.toFixed(2)+'</span><span>GST '+report.grandGst.toFixed(2)+'</span><span>Total '+report.grandTotal.toFixed(2)+'</span>';
-  }
+  var sectionSummary='Section Totals ('+escapeHtml(sectionTotals.name)+'): Ex. GST '+(sectionTotals.subtotalEx||0).toFixed(2)+' | GST '+(sectionTotals.subtotalGst||0).toFixed(2)+' | Incl. GST '+(sectionTotals.subtotalTotal||0).toFixed(2);
+  bFoot.innerHTML='<tr><td colspan="5" class="section-total-cell">'+sectionSummary+'</td><td></td></tr>';
+  updateGrandTotals(report);
   if(window.Sortable && !bBody.getAttribute('data-sortable')){
     Sortable.create(bBody,{handle:'.sort-handle',draggable:'tr.main-row',animation:150,onEnd:function(){
       var rows=bBody.querySelectorAll('tr.main-row');
@@ -727,21 +790,28 @@ function exportBasketToCsv(opts){
   if(!basket.length) return false;
   var esc=function(v){return '"'+String(v).replace(/"/g,'""')+'"';};
   var report=buildReportModel(basket,sections);
-  var lines=[["Section","Item","Quantity","Price Ex. GST","Line Ex","GST","Line Total"]];
+  var lines=[["Section","Item","Quantity","Price","Line Total"]];
   for(var si=0;si<report.sections.length;si++){
     var sec=report.sections[si];
     for(var gi=0;gi<sec.items.length;gi++){
       var grp=sec.items[gi];
       var p=grp.parent; var le=isNaN(p.ex)?0:(p.qty||1)*p.ex; var gstAmt=le*GST_RATE; var li=le+gstAmt;
-      lines.push([sec.name,(p.item||''),(p.qty||1),isNaN(p.ex)?"N/A":Number(p.ex).toFixed(2),isNaN(p.ex)?"N/A":le.toFixed(2),isNaN(p.ex)?"N/A":gstAmt.toFixed(2),isNaN(p.ex)?"N/A":li.toFixed(2)]);
+      lines.push([sec.name,(p.item||''),(p.qty||1),isNaN(p.ex)?"N/A":Number(p.ex).toFixed(2),isNaN(p.ex)?"N/A":li.toFixed(2)]);
       var subs=grp.subs||[];
       for(var sj=0;sj<subs.length;sj++){
         var s=subs[sj]; var sle=isNaN(s.ex)?0:(s.qty||1)*s.ex; var sg=sle*GST_RATE; var st=sle+sg;
-        lines.push([sec.name,' - '+(s.item||''),(s.qty||1),isNaN(s.ex)?"N/A":Number(s.ex).toFixed(2),isNaN(s.ex)?"N/A":sle.toFixed(2),isNaN(s.ex)?"N/A":sg.toFixed(2),isNaN(s.ex)?"N/A":st.toFixed(2)]);
+        lines.push([sec.name,' - '+(s.item||''),(s.qty||1),isNaN(s.ex)?"N/A":Number(s.ex).toFixed(2),isNaN(s.ex)?"N/A":st.toFixed(2)]);
       }
     }
   }
-  lines.push(["Totals","","","",report.grandEx.toFixed(2),report.grandGst.toFixed(2),report.grandTotal.toFixed(2)]);
+  var discountedEx=recalcGrandTotal(report.grandEx,discountPercent);
+  var gstAfter=calculateGst(discountedEx);
+  var grandIncl=roundCurrency(discountedEx+gstAfter);
+  lines.push(["Total (Ex GST)","","","",formatCurrency(report.grandEx)]);
+  lines.push(["Discount (%)","","","",formatPercent(discountPercent)]);
+  lines.push(["Grand Total (Ex GST)","","","",formatCurrency(discountedEx)]);
+  lines.push(["GST","","","",formatCurrency(gstAfter)]);
+  lines.push(["Grand Total (Incl. GST)","","","",formatCurrency(grandIncl)]);
   var out=[]; for(var r=0;r<lines.length;r++){ var row=lines[r]; for(var c=0;c<row.length;c++){ row[c]=esc(row[c]); } out.push(row.join(',')); }
   var csv=out.join("\n"); var blob=new Blob([csv],{type:"text/csv"}); var a=document.createElement("a"); a.href=URL.createObjectURL(blob); a.download="quote_basket.csv"; document.body.appendChild(a); a.click(); document.body.removeChild(a);
   if(!(opts&&opts.silent)){ showToast('Quote CSV exported'); }
@@ -755,6 +825,9 @@ function resetQuote(toastMessage){
   var first=sections[0];
   activeSectionId=first?first.id:1;
   sectionSeq=first?first.id:sectionSeq;
+  discountPercent=0;
+  currentGrandTotal=0;
+  lastBaseTotal=0;
   renderBasket();
   if(toastMessage){ showToast(toastMessage); }
 }


### PR DESCRIPTION
## Summary
- rename the price column and remove the ex GST/GST columns to widen the item area
- add the new totals table with discount/grand total interaction and automatic GST calculations
- update the CSV export and storage logic to persist the discount value alongside the new layout
- keep the totals table visible (read-only) when the basket is empty so the refreshed layout is immediately apparent

## Testing
- Screenshot: browser:/invocations/azljhgmz/artifacts/artifacts/quote-builder-update.png

------
https://chatgpt.com/codex/tasks/task_e_68e7dc585138832796ba2bcd7179e973