### PR TITLE
Fix duplicate totals panel regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Defender Price List.xlsx   # Workbook loaded by the app
 
 ## Versioning
 
+- **2.0.1** – Fixed merge regression that duplicated the totals sidebar and broke the main script bootstrap
 - **2.0.0** – Added per-section notes, Ex. GST line totals, and redesigned totals sidebar with synced discount logic
 - **1.2.0** – Quote Builder moved to the main page; Catalogue lives in the floating window with macOS-style controls
 - **1.1.1** – Sections UI refinements, bug fixes

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-<title>DefCost 2.0.0</title>
+<title>DefCost 2.0.1</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -88,7 +88,6 @@ summary:hover{background:var(--btn);color:#fff}
 
 #grandTotals{margin-top:0;padding:.75rem;border:1px solid var(--border);border-radius:8px;background:var(--panel);display:none;font-weight:600;align-self:flex-start;min-width:0}
 @media(min-width:960px){#basketContent{flex-direction:row;align-items:flex-start}#grandTotals{min-width:260px;margin-left:auto}}
- main
 #sectionTabsBar{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;padding:.35rem .5rem;background:var(--header);border:1px solid var(--border);border-top:0}
 #sectionTabs{display:flex;flex-wrap:wrap;gap:.25rem}
 .section-tab{display:inline-flex;align-items:center;gap:.35rem;padding:.3rem .6rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg);cursor:pointer;transition:.2s}
@@ -129,7 +128,6 @@ summary:hover{background:var(--btn);color:#fff}
 #basketTable th:nth-child(6),#basketTable td:nth-child(6){width:50px}
 #basketTable col#col-item,#basketHead col#col-item{width:auto}
 #grandTotals h3{margin:0 0 .4rem;font-size:1.05rem;font-weight:700}
- main
 .grand-totals-table{width:100%;border-collapse:collapse}
 .grand-totals-table th,.grand-totals-table td{padding:.35rem .45rem;border-bottom:1px solid var(--border);text-align:left;font-weight:600}
 .grand-totals-table tr:last-child th,.grand-totals-table tr:last-child td{border-bottom:0}
@@ -158,7 +156,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-<h1>DefCost 2.0.0</h1>
+<h1>DefCost 2.0.1</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">
@@ -217,11 +215,7 @@ input[type=number]{-moz-appearance:textfield}
       </div>
 
       <aside id="grandTotals"></aside>
- main
     </div>
-  </div>
-  <div class="quote-totals-row">
-    <aside id="grandTotals"></aside>
   </div>
 </div>
 <div id="catalogWindow" aria-label="Catalogue window" role="dialog" aria-modal="false">
@@ -412,7 +406,6 @@ function formatPercent(val){return roundCurrency(isFinite(val)?val:0).toFixed(2)
 function recalcGrandTotal(base,discount){var b=isFinite(base)?base:0;var d=isFinite(discount)?discount:0;var computed=b*(1-d/100);if(!isFinite(computed))computed=0;return roundCurrency(computed<0?0:computed);}
 function calculateGst(amount){var base=isFinite(amount)?amount:0;return roundCurrency(base*GST_RATE);}
 function ensureGrandTotalsUi(){if(!grandTotalsEl||grandTotalsUi)return;if(!grandTotalsEl)return;grandTotalsEl.innerHTML='<h3>Totals</h3><table class="grand-totals-table"><tbody><tr><th scope="row">Total</th><td class="totals-value" data-role="total-value">0.00</td></tr><tr><th scope="row">Discount (%)</th><td><div class="grand-totals-input"><input type="number" step="0.01" inputmode="decimal" aria-label="Discount percentage" data-role="discount-input"><span>%</span></div></td></tr><tr><th scope="row">Grand Total</th><td><div class="grand-totals-input"><input type="number" min="0" step="0.01" inputmode="decimal" aria-label="Grand total after discount" data-role="grand-total-input"></div></td></tr><tr><th scope="row">GST (10%)</th><td class="totals-value" data-role="gst-value">0.00</td></tr><tr><th scope="row">Grand Total (Incl. GST)</th><td class="totals-value" data-role="grand-incl-value">0.00</td></tr></tbody></table>';
- main
   var discountInput=grandTotalsEl.querySelector('[data-role="discount-input"]');
   var grandTotalInput=grandTotalsEl.querySelector('[data-role="grand-total-input"]');
   grandTotalsUi={container:grandTotalsEl,totalValue:grandTotalsEl.querySelector('[data-role="total-value"]'),discountInput:discountInput,grandTotalInput:grandTotalInput,gstValue:grandTotalsEl.querySelector('[data-role="gst-value"]'),grandInclValue:grandTotalsEl.querySelector('[data-role="grand-incl-value"]')};


### PR DESCRIPTION
## Summary
- remove merge-conflict artefacts that duplicated the totals sidebar and broke the script bootstrap
- bump the displayed version to 2.0.1 and document the fix in the README

## Testing
- Manual: Loaded `index.html` through `python3 -m http.server 8000` and verified the UI in the browser


------
https://chatgpt.com/codex/tasks/task_e_68e7f6f3a93483279878f36e47e55598