### PR TITLE
Reposition the quote totals table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It loads an Excel workbook of products/services and lets estimators build quotes
 - **Section notes**: dedicated notes field stored alongside each section in localStorage
 - **Reorder**: drag-and-drop for items (and keep sub-items with their parent)
 - **Totals**:
-  - Compact sidebar summarises **Total (Ex. GST)**, **Discount %**, **Grand Total (Ex. GST)**, **GST (10%)**, **Grand Total (Incl. GST)**
+  - Right-aligned summary table (beneath the active section) lists **Total (Ex. GST)**, **Discount %**, **Grand Total (Ex. GST)**, **GST (10%)**, **Grand Total (Incl. GST)**
   - Discount % and Grand Total inputs stay in sync
 - **CSV export**: section-aware, includes grand totals
 - **Clipboard**: click any non-input cell to copy its text
@@ -84,6 +84,7 @@ Defender Price List.xlsx   # Workbook loaded by the app
 
 ## Versioning
 
+- **2.0.2** – Repositioned the quote totals into a dedicated table beneath the sections
 - **2.0.1** – Fixed merge regression that duplicated the totals sidebar and broke the main script bootstrap
 - **2.0.0** – Added per-section notes, Ex. GST line totals, and redesigned totals sidebar with synced discount logic
 - **1.2.0** – Quote Builder moved to the main page; Catalogue lives in the floating window with macOS-style controls

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-<title>DefCost 2.0.1</title>
+<title>DefCost 2.0.2</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -85,9 +85,9 @@ summary:hover{background:var(--btn);color:#fff}
 #basketContainer{display:flex;flex-direction:column;min-height:100%;gap:0}
 #basketContent{display:flex;flex-direction:column;gap:1rem}
 .basket-table-area{flex:1 1 auto;min-width:0}
+.grand-totals-wrapper{display:none;justify-content:flex-end;margin-top:.75rem}
 
-#grandTotals{margin-top:0;padding:.75rem;border:1px solid var(--border);border-radius:8px;background:var(--panel);display:none;font-weight:600;align-self:flex-start;min-width:0}
-@media(min-width:960px){#basketContent{flex-direction:row;align-items:flex-start}#grandTotals{min-width:260px;margin-left:auto}}
+#grandTotals{margin:0;padding:.75rem;border:1px solid var(--border);border-radius:8px;background:var(--panel);display:none;font-weight:600;width:min(320px,100%);max-width:340px}
 #sectionTabsBar{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;padding:.35rem .5rem;background:var(--header);border:1px solid var(--border);border-top:0}
 #sectionTabs{display:flex;flex-wrap:wrap;gap:.25rem}
 .section-tab{display:inline-flex;align-items:center;gap:.35rem;padding:.3rem .6rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg);cursor:pointer;transition:.2s}
@@ -127,7 +127,6 @@ summary:hover{background:var(--btn);color:#fff}
 #basketTable th:nth-child(5),#basketTable td:nth-child(5){width:150px}
 #basketTable th:nth-child(6),#basketTable td:nth-child(6){width:50px}
 #basketTable col#col-item,#basketHead col#col-item{width:auto}
-#grandTotals h3{margin:0 0 .4rem;font-size:1.05rem;font-weight:700}
 .grand-totals-table{width:100%;border-collapse:collapse}
 .grand-totals-table th,.grand-totals-table td{padding:.35rem .45rem;border-bottom:1px solid var(--border);text-align:left;font-weight:600}
 .grand-totals-table tr:last-child th,.grand-totals-table tr:last-child td{border-bottom:0}
@@ -156,7 +155,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-<h1>DefCost 2.0.1</h1>
+<h1>DefCost 2.0.2</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">
@@ -213,9 +212,10 @@ input[type=number]{-moz-appearance:textfield}
         <tbody></tbody><tfoot></tfoot>
       </table>
       </div>
-
-      <aside id="grandTotals"></aside>
     </div>
+  </div>
+  <div class="grand-totals-wrapper">
+    <aside id="grandTotals" aria-live="polite"></aside>
   </div>
 </div>
 <div id="catalogWindow" aria-label="Catalogue window" role="dialog" aria-modal="false">
@@ -247,7 +247,7 @@ var FALL=META["uncategorised"];
 var PRICE_EX=["Rate Ex. GST","Price Ex. GST","Price","Price Ex Tax","Price ex GST"];
 var TOAST_MS=3000,GST_RATE=0.10,LS_KEY='defcost_basket_v2',UI_KEY='defcost_qb_ui_v1';
 var wb=null,basket=[],sections=getDefaultSections(),uid=0,sectionSeq=1,activeSectionId=sections[0].id,captureParentId=null;
-var tabs=document.getElementById("sheetTabs"),container=document.getElementById("sheetContainer"),toast=document.getElementById("toast"),sectionTabsEl=document.getElementById("sectionTabs"),grandTotalsEl=document.getElementById("grandTotals");
+var tabs=document.getElementById("sheetTabs"),container=document.getElementById("sheetContainer"),toast=document.getElementById("toast"),sectionTabsEl=document.getElementById("sectionTabs"),grandTotalsEl=document.getElementById("grandTotals"),grandTotalsWrap=document.querySelector('.grand-totals-wrapper');
 var discountPercent=0,currentGrandTotal=0,lastBaseTotal=0,grandTotalsUi=null,latestReport=null;
 var qbWindow=document.getElementById('catalogWindow'),qbTitlebar=document.getElementById('catalogTitlebar'),qbDockIcon=document.getElementById('catalogDockIcon'),qbMin=document.getElementById('catalogMin'),qbClose=document.getElementById('catalogClose'),qbZoom=document.getElementById('catalogZoom'),qbResizeHandle=document.getElementById('catalogResizeHandle');
 var addSectionBtn=document.getElementById("addSectionBtn"),qbTitle=document.getElementById('qbTitle'),clearQuoteBtn=document.getElementById('clearQuoteBtn');
@@ -405,7 +405,7 @@ function formatCurrency(val){return roundCurrency(isFinite(val)?val:0).toFixed(2
 function formatPercent(val){return roundCurrency(isFinite(val)?val:0).toFixed(2);}
 function recalcGrandTotal(base,discount){var b=isFinite(base)?base:0;var d=isFinite(discount)?discount:0;var computed=b*(1-d/100);if(!isFinite(computed))computed=0;return roundCurrency(computed<0?0:computed);}
 function calculateGst(amount){var base=isFinite(amount)?amount:0;return roundCurrency(base*GST_RATE);}
-function ensureGrandTotalsUi(){if(!grandTotalsEl||grandTotalsUi)return;if(!grandTotalsEl)return;grandTotalsEl.innerHTML='<h3>Totals</h3><table class="grand-totals-table"><tbody><tr><th scope="row">Total</th><td class="totals-value" data-role="total-value">0.00</td></tr><tr><th scope="row">Discount (%)</th><td><div class="grand-totals-input"><input type="number" step="0.01" inputmode="decimal" aria-label="Discount percentage" data-role="discount-input"><span>%</span></div></td></tr><tr><th scope="row">Grand Total</th><td><div class="grand-totals-input"><input type="number" min="0" step="0.01" inputmode="decimal" aria-label="Grand total after discount" data-role="grand-total-input"></div></td></tr><tr><th scope="row">GST (10%)</th><td class="totals-value" data-role="gst-value">0.00</td></tr><tr><th scope="row">Grand Total (Incl. GST)</th><td class="totals-value" data-role="grand-incl-value">0.00</td></tr></tbody></table>';
+function ensureGrandTotalsUi(){if(!grandTotalsEl||grandTotalsUi)return;if(!grandTotalsEl)return;grandTotalsEl.innerHTML='<table class="grand-totals-table" aria-label="Quote totals"><tbody><tr><th scope="row">Total</th><td class="totals-value" data-role="total-value">0.00</td></tr><tr><th scope="row">Discount (%)</th><td><div class="grand-totals-input"><input type="number" step="0.01" inputmode="decimal" aria-label="Discount percentage" data-role="discount-input"><span>%</span></div></td></tr><tr><th scope="row">Grand Total</th><td><div class="grand-totals-input"><input type="number" min="0" step="0.01" inputmode="decimal" aria-label="Grand total after discount" data-role="grand-total-input"></div></td></tr><tr><th scope="row">GST (10%)</th><td class="totals-value" data-role="gst-value">0.00</td></tr><tr><th scope="row">Grand Total (Incl. GST)</th><td class="totals-value" data-role="grand-incl-value">0.00</td></tr></tbody></table>';
   var discountInput=grandTotalsEl.querySelector('[data-role="discount-input"]');
   var grandTotalInput=grandTotalsEl.querySelector('[data-role="grand-total-input"]');
   grandTotalsUi={container:grandTotalsEl,totalValue:grandTotalsEl.querySelector('[data-role="total-value"]'),discountInput:discountInput,grandTotalInput:grandTotalInput,gstValue:grandTotalsEl.querySelector('[data-role="gst-value"]'),grandInclValue:grandTotalsEl.querySelector('[data-role="grand-incl-value"]')};
@@ -422,6 +422,7 @@ function updateGrandTotals(report,opts){
   var hasItems=basket&&basket.length>0;
   var base=report&&isFinite(report.grandEx)?report.grandEx:0;
   if(!hasItems){
+    if(grandTotalsWrap) grandTotalsWrap.style.display='none';
     grandTotalsEl.style.display='none';
     if(grandTotalsUi.totalValue)grandTotalsUi.totalValue.textContent=formatCurrency(0);
     if(grandTotalsUi.gstValue)grandTotalsUi.gstValue.textContent=formatCurrency(0);
@@ -440,6 +441,7 @@ function updateGrandTotals(report,opts){
     }
     return;
   }
+  if(grandTotalsWrap) grandTotalsWrap.style.display='flex';
   grandTotalsEl.style.display='block';
   if(!(opts&&opts.preserveGrandTotal)){
     if(Math.abs(base-lastBaseTotal)>0.005){


### PR DESCRIPTION
## Summary
- reposition the quote totals into a dedicated right-aligned table after the sections and drop the old header label
- update totals logic to manage the new wrapper visibility and maintain accessibility metadata
- bump the displayed version to 2.0.2 and document the layout change in the README

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f9cafd5883278c85ff40b4ba347f