### PR TITLE
Bump DefCost to 2.0.3 and harden dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Defender Price List.xlsx   # Workbook loaded by the app
 
 ## Versioning
 
+- **2.0.3** – Hardened the dark mode toggle binding and bumped the displayed version
 - **2.0.2** – Repositioned the quote totals into a dedicated table beneath the sections
 - **2.0.1** – Fixed merge regression that duplicated the totals sidebar and broke the main script bootstrap
 - **2.0.0** – Added per-section notes, Ex. GST line totals, and redesigned totals sidebar with synced discount logic

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-<title>DefCost 2.0.2</title>
+<title>DefCost 2.0.3</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -155,7 +155,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-<h1>DefCost 2.0.2</h1>
+<h1>DefCost 2.0.3</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">
@@ -547,7 +547,12 @@ function removeSection(sectionId){
   showToast('Deleted '+deletedName);
 }
 loadBasket();
-document.getElementById("darkModeToggle").onclick=function(){document.body.classList.toggle("dark-mode")};
+var darkModeToggle=document.getElementById('darkModeToggle');
+if(darkModeToggle){
+  darkModeToggle.addEventListener('click',function(){
+    document.body.classList.toggle('dark-mode');
+  });
+}
 var statusEl=document.getElementById('status');var pickerWrap=document.getElementById('manualLoad');var picker=document.getElementById('xlsxPicker');
 function showStatus(html){if(statusEl){statusEl.innerHTML=html;}}
 function showPicker(reason){showStatus('<span style="color:#b00">Couldn\'t load <code>Defender Price List.xlsx</code> ('+reason+').</span> You can upload the workbook manually below.');if(pickerWrap)pickerWrap.style.display='block';}


### PR DESCRIPTION
## Summary
- bump the displayed DefCost version to 2.0.3 in the UI and README
- guard the dark mode toggle binding to avoid runtime errors if the control is missing

## Testing
- Manual Playwright load of `index.html`


------
https://chatgpt.com/codex/tasks/task_e_68e83e25cbbc8327a576b4f299e8ee16