### PR TITLE
Update quote header text and reduce builder title size

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Defender Price List.xlsx   # Workbook loaded by the app
 
 ## Versioning
 
+- **2.0.5** – Simplified line total header copy and reduced Quote Builder title size
 - **2.0.4** – Refined section tabs, tightened quote row spacing, refreshed notes + totals styling
 - **2.0.3** – Hardened the dark mode toggle binding and bumped the displayed version
 - **2.0.2** – Repositioned the quote totals into a dedicated table beneath the sections

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-<title>DefCost 2.0.4</title>
+<title>DefCost 2.0.5</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -46,7 +46,7 @@ summary:hover{background:var(--btn);color:#fff}
 #quoteBuilderMain{margin-top:1.5rem;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:0 16px 40px rgba(0,0,0,.18);padding:1rem 1.25rem 1.5rem;display:flex;flex-direction:column;gap:1rem}
 #quoteHeader{display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:.75rem}
 .quote-header-left{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}
-#quoteHeader #qbTitle{margin:0;font-size:1.75rem;font-weight:bold}
+#quoteHeader #qbTitle{margin:0;font-size:1.55rem;font-weight:bold}
 #quoteActions{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:flex-end}
 #quoteActions button{background:var(--btn);color:#fff;border:none;padding:.4rem .75rem;border-radius:6px;cursor:pointer;font-weight:600}
 #quoteActions button:hover{background:var(--btnh)}
@@ -156,7 +156,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-<h1>DefCost 2.0.4</h1>
+<h1>DefCost 2.0.5</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">
@@ -189,7 +189,7 @@ input[type=number]{-moz-appearance:textfield}
           <thead><tr>
             <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
             <th>Price</th>
-            <th>Line Total (Ex. GST)</th><th></th>
+            <th>Line Total</th><th></th>
           </tr></thead>
         </table>
       </div>
@@ -205,11 +205,11 @@ input[type=number]{-moz-appearance:textfield}
           <col style="width:140px">
           <col style="width:50px">
         </colgroup>
-        <thead><tr>
-          <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
-          <th>Price</th>
-          <th>Line Total (Ex. GST)</th><th></th>
-        </tr></thead>
+          <thead><tr>
+            <th class="sort-handle">≡</th><th>Item</th><th>Quantity</th>
+            <th>Price</th>
+            <th>Line Total</th><th></th>
+          </tr></thead>
         <tbody></tbody><tfoot></tfoot>
       </table>
       </div>


### PR DESCRIPTION
## Summary
- shorten the quote table line total header to “Line Total” in both sticky and main tables
- reduce the Quote Builder title size for a lighter header presentation
- bump the displayed version to 2.0.5 and record the change in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e855e63de4832790b3d45919eeba8d