### PR TITLE
Release DefCost 3.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Defender.jpeg              # Brand image / logo
 
 ## Versioning
 
-- **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.  
+- **3.0.7** – Fixed zero-qty totals, prevented duplicate section names (case-insensitive), and made blank prices import/export safe.
+- **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.
 - **3.0.5** – Hybrid modularisation B: Moved renderBasket into /ui.js. No functional changes.  
 - **3.0.4** – Hybrid modularisation A: Introduced global namespace and moved Import Summary modal + toast to /ui.js. No functional changes.  
 - **3.0.3** – Split calculation and storage logic into calc.js and storage.js. No behavioural changes.  

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.6</title>
+  <title>DefCost 3.0.7</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -186,7 +186,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-        <h1>DefCost 3.0.6</h1>
+        <h1>DefCost 3.0.7</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">

--- a/js/calc.js
+++ b/js/calc.js
@@ -96,7 +96,8 @@ export function buildReportModel(basket, sections) {
   }
 
   function addAmounts(obj, qty, ex) {
-    const lineEx = isNaN(ex) ? 0 : (qty || 1) * ex;
+    const safeQty = Number.isFinite(qty) ? qty : 1;
+    const lineEx = isNaN(ex) ? 0 : safeQty * ex;
     const gst = lineEx * GST_RATE;
     obj.subtotalEx += lineEx;
     obj.subtotalGst += gst;

--- a/js/main.js
+++ b/js/main.js
@@ -585,7 +585,7 @@ function renderSectionTabs(){
       tab.onclick=function(){ if(activeSectionId!==sec.id){ activeSectionId=sec.id; captureParentId=null; window.DefCost.ui.renderBasket(); } };
       var nameSpan=document.createElement('span'); nameSpan.className='section-name'; nameSpan.textContent=sec.name; tab.appendChild(nameSpan);
       var renameBtn=document.createElement('button'); renameBtn.type='button'; renameBtn.textContent='✎'; renameBtn.title='Rename section';
-      renameBtn.onclick=function(ev){ ev.stopPropagation(); var newName=prompt('Section name',sec.name); if(newName===null) return; newName=newName.trim(); if(!newName){ showToast('Section name is required'); return; } sec.name=newName; window.DefCost.ui.renderBasket(); showToast('Section renamed'); };
+      renameBtn.onclick=function(ev){ ev.stopPropagation(); var newName=prompt('Section name',sec.name); if(newName===null) return; newName=newName.trim(); if(!newName){ showToast('Section name is required'); return; } var normalized=newName.toLowerCase().trim(); for(var si2=0;si2<sections.length;si2++){ var existing=sections[si2]; if(!existing||existing.id===sec.id) continue; var existingName=((existing.name||existing.title)||'').toLowerCase().trim(); if(existingName===normalized){ showToast('A section named \u2018'+newName+'\u2019 already exists.'); return; } } sec.name=newName; window.DefCost.ui.renderBasket(); showToast('Section renamed'); };
       tab.appendChild(renameBtn);
       if(sections.length>1){
         var delBtn=document.createElement('button'); delBtn.type='button'; delBtn.textContent='✕'; delBtn.title='Delete section';
@@ -681,7 +681,7 @@ if(bFootEl){
     navigator.clipboard.writeText(text).then(function(){ td.classList.add('copied-cell'); void td.offsetWidth; setTimeout(function(){ td.classList.remove('copied-cell'); },150); }).catch(function(){});
   });
 }
-if(addSectionBtn){addSectionBtn.addEventListener('click',function(){ensureSectionState();var suggestion='Section '+(sectionSeq+1);var name=prompt('Section name',suggestion);if(name===null)return;name=name.trim();if(!name){showToast('Section name is required');return;}var newId=sectionSeq+1;sections.push({id:newId,name:name,notes:''});sectionSeq=newId;activeSectionId=newId;captureParentId=null;window.DefCost.ui.renderBasket();showToast('Section added');});}
+if(addSectionBtn){addSectionBtn.addEventListener('click',function(){ensureSectionState();var suggestion='Section '+(sectionSeq+1);var name=prompt('Section name',suggestion);if(name===null)return;name=name.trim();if(!name){showToast('Section name is required');return;}var normalized=name.toLowerCase().trim();for(var si=0;si<sections.length;si++){var existing=sections[si];var existingName=((existing&&(existing.name||existing.title))||'').toLowerCase().trim();if(existingName===normalized){showToast('A section named \u2018'+name+'\u2019 already exists.');return;}}var newId=sectionSeq+1;sections.push({id:newId,name:name,notes:''});sectionSeq=newId;activeSectionId=newId;captureParentId=null;window.DefCost.ui.renderBasket();showToast('Section added');});}
 if(importBtn&&importInput){
   importBtn.addEventListener('click',function(){
     importInput.value='';

--- a/js/storage.js
+++ b/js/storage.js
@@ -299,6 +299,9 @@ function parseNumericCell(raw, rowNumber, label, issues) {
   }
   const num = parseFloat(cleaned);
   if (!isFinite(num)) {
+    if (label === 'Price') {
+      return { value: 0 };
+    }
     issues.push('Row ' + rowNumber + ': ' + label + ' is not a number');
     return { value: 0, invalid: true };
   }
@@ -399,24 +402,26 @@ export function exportBasketToCsv({
     for (let gi = 0; gi < sec.items.length; gi++) {
       const group = sec.items[gi];
       const parent = group.parent;
-      const lineEx = isNaN(parent.ex) ? NaN : (parent.qty || 1) * parent.ex;
+      const safeParentQty = Number.isFinite(parent.qty) ? parent.qty : 1;
+      const lineEx = isNaN(parent.ex) ? NaN : safeParentQty * parent.ex;
       lines.push([
         sec.name,
         parent.item || '',
-        parent.qty || 1,
-        isNaN(parent.ex) ? 'N/A' : Number(parent.ex).toFixed(2),
-        isNaN(lineEx) ? 'N/A' : lineEx.toFixed(2)
+        safeParentQty,
+        Number.isFinite(parent.ex) ? Number(parent.ex).toFixed(2) : '',
+        isNaN(lineEx) ? '' : lineEx.toFixed(2)
       ]);
       const subs = group.subs || [];
       for (let sj = 0; sj < subs.length; sj++) {
         const sub = subs[sj];
-        const subLineEx = isNaN(sub.ex) ? NaN : (sub.qty || 1) * sub.ex;
+        const safeSubQty = Number.isFinite(sub.qty) ? sub.qty : 1;
+        const subLineEx = isNaN(sub.ex) ? NaN : safeSubQty * sub.ex;
         lines.push([
           sec.name,
           ' - ' + (sub.item || ''),
-          sub.qty || 1,
-          isNaN(sub.ex) ? 'N/A' : Number(sub.ex).toFixed(2),
-          isNaN(subLineEx) ? 'N/A' : subLineEx.toFixed(2)
+          safeSubQty,
+          Number.isFinite(sub.ex) ? Number(sub.ex).toFixed(2) : '',
+          isNaN(subLineEx) ? '' : subLineEx.toFixed(2)
         ]);
       }
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -496,15 +496,17 @@ window.DefCost.ui = window.DefCost.ui || {};
       inp.type = 'number';
       inp.step = '0.1';
       inp.className = 'qty-input';
-      inp.value = b.qty || 1;
+      inp.value = Number.isFinite(b.qty) ? b.qty : 1;
       var plus = document.createElement('button');
       plus.textContent = '+';
       minus.onclick = function () {
-        b.qty = Math.max(1, (b.qty || 1) - 1);
+        var baseQty = Number.isFinite(b.qty) ? b.qty : 1;
+        b.qty = Math.max(1, baseQty - 1);
         renderBasket();
       };
       plus.onclick = function () {
-        b.qty = (b.qty || 1) + 1;
+        var baseQty = Number.isFinite(b.qty) ? b.qty : 1;
+        b.qty = baseQty + 1;
         renderBasket();
       };
       inp.onchange = function () {
@@ -529,7 +531,8 @@ window.DefCost.ui = window.DefCost.ui || {};
       };
       tdEx.appendChild(exInput);
       tr.appendChild(tdEx);
-      var lineTotal = isNaN(b.ex) ? NaN : (b.qty || 1) * b.ex;
+      var safeQty = Number.isFinite(b.qty) ? b.qty : 1;
+      var lineTotal = isNaN(b.ex) ? NaN : safeQty * b.ex;
       var tdLi = document.createElement('td');
       tdLi.textContent = isNaN(lineTotal) ? 'N/A' : lineTotal.toFixed(2);
       tr.appendChild(tdLi);
@@ -603,15 +606,17 @@ window.DefCost.ui = window.DefCost.ui || {};
           inp.type = 'number';
           inp.step = '0.1';
           inp.className = 'qty-input';
-          inp.value = s.qty || 1;
+          inp.value = Number.isFinite(s.qty) ? s.qty : 1;
           var plus = document.createElement('button');
           plus.textContent = '+';
           minus.onclick = function () {
-            s.qty = Math.max(1, (s.qty || 1) - 1);
+            var baseQty = Number.isFinite(s.qty) ? s.qty : 1;
+            s.qty = Math.max(1, baseQty - 1);
             renderBasket();
           };
           plus.onclick = function () {
-            s.qty = (s.qty || 1) + 1;
+            var baseQty = Number.isFinite(s.qty) ? s.qty : 1;
+            s.qty = baseQty + 1;
             renderBasket();
           };
           inp.onchange = function () {
@@ -636,7 +641,8 @@ window.DefCost.ui = window.DefCost.ui || {};
           };
           c4.appendChild(exInput);
           sr.appendChild(c4);
-          var lineSubTotal = isNaN(s.ex) ? NaN : (s.qty || 1) * s.ex;
+          var safeQty = Number.isFinite(s.qty) ? s.qty : 1;
+          var lineSubTotal = isNaN(s.ex) ? NaN : safeQty * s.ex;
           var c5 = document.createElement('td');
           c5.textContent = isNaN(lineSubTotal) ? 'N/A' : lineSubTotal.toFixed(2);
           sr.appendChild(c5);


### PR DESCRIPTION
## Summary
- ensure quantity math treats zero values correctly across calculations, UI rendering, and CSV export
- block duplicate section names case-insensitively and surface a toast when a collision is detected
- export blank prices as empty cells and allow CSV imports with empty or non-numeric prices to default to zero

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ef9ace7dd08327a91aa1e011430e30