### PR TITLE
Prevent duplicate section names

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Defender.jpeg              # Brand image / logo
 
 ## Versioning
 
-- **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.  
+- **3.0.7** – Prevented duplicate Section names (case-insensitive) to maintain clean CSV import/export integrity.
+- **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.
 - **3.0.5** – Hybrid modularisation B: Moved renderBasket into /ui.js. No functional changes.  
 - **3.0.4** – Hybrid modularisation A: Introduced global namespace and moved Import Summary modal + toast to /ui.js. No functional changes.  
 - **3.0.3** – Split calculation and storage logic into calc.js and storage.js. No behavioural changes.  

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.6</title>
+  <title>DefCost 3.0.7</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -186,7 +186,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-        <h1>DefCost 3.0.6</h1>
+        <h1>DefCost 3.0.7</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">

--- a/js/main.js
+++ b/js/main.js
@@ -118,6 +118,10 @@ function persistBackup(){
   backupCurrentQuote({basket:basket,sections:sections,activeSectionId:activeSectionId,discountPercent:discountPercent});
 }
 
+function normalizeSectionName(value){
+  return value==null?'':String(value).toLowerCase().trim();
+}
+
 function exportQuoteToCsv(opts){
   return exportBasketToCsv({
     basket:basket,
@@ -585,7 +589,7 @@ function renderSectionTabs(){
       tab.onclick=function(){ if(activeSectionId!==sec.id){ activeSectionId=sec.id; captureParentId=null; window.DefCost.ui.renderBasket(); } };
       var nameSpan=document.createElement('span'); nameSpan.className='section-name'; nameSpan.textContent=sec.name; tab.appendChild(nameSpan);
       var renameBtn=document.createElement('button'); renameBtn.type='button'; renameBtn.textContent='✎'; renameBtn.title='Rename section';
-      renameBtn.onclick=function(ev){ ev.stopPropagation(); var newName=prompt('Section name',sec.name); if(newName===null) return; newName=newName.trim(); if(!newName){ showToast('Section name is required'); return; } sec.name=newName; window.DefCost.ui.renderBasket(); showToast('Section renamed'); };
+      renameBtn.onclick=function(ev){ ev.stopPropagation(); var newName=prompt('Section name',sec.name); if(newName===null) return; newName=newName.trim(); if(!newName){ showToast('Section name is required'); return; } var newNameNorm=normalizeSectionName(newName); var exists=sections.some(function(other){ return other&&other.id!==sec.id&&normalizeSectionName(other.name)===newNameNorm; }); if(exists){ showToast('A section named “'+newName+'” already exists.'); return; } sec.name=newName; window.DefCost.ui.renderBasket(); showToast('Section renamed'); };
       tab.appendChild(renameBtn);
       if(sections.length>1){
         var delBtn=document.createElement('button'); delBtn.type='button'; delBtn.textContent='✕'; delBtn.title='Delete section';
@@ -681,7 +685,7 @@ if(bFootEl){
     navigator.clipboard.writeText(text).then(function(){ td.classList.add('copied-cell'); void td.offsetWidth; setTimeout(function(){ td.classList.remove('copied-cell'); },150); }).catch(function(){});
   });
 }
-if(addSectionBtn){addSectionBtn.addEventListener('click',function(){ensureSectionState();var suggestion='Section '+(sectionSeq+1);var name=prompt('Section name',suggestion);if(name===null)return;name=name.trim();if(!name){showToast('Section name is required');return;}var newId=sectionSeq+1;sections.push({id:newId,name:name,notes:''});sectionSeq=newId;activeSectionId=newId;captureParentId=null;window.DefCost.ui.renderBasket();showToast('Section added');});}
+if(addSectionBtn){addSectionBtn.addEventListener('click',function(){ensureSectionState();var suggestion='Section '+(sectionSeq+1);var name=prompt('Section name',suggestion);if(name===null)return;name=name.trim();if(!name){showToast('Section name is required');return;}var nameNorm=normalizeSectionName(name);var exists=sections.some(function(sec){return sec&&normalizeSectionName(sec.name)===nameNorm;});if(exists){showToast('A section named “'+name+'” already exists.');return;}var newId=sectionSeq+1;sections.push({id:newId,name:name,notes:''});sectionSeq=newId;activeSectionId=newId;captureParentId=null;window.DefCost.ui.renderBasket();showToast('Section added');});}
 if(importBtn&&importInput){
   importBtn.addEventListener('click',function(){
     importInput.value='';


### PR DESCRIPTION
## Summary
- block creating or renaming sections when another section already uses the normalized name
- add a helper to normalize section names for duplicate checks and show a toast warning when blocked
- bump the UI version to 3.0.7 and document the change in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efa3de70e4832797c40cce8a67d56b