### PR TITLE
Add all-tabs catalogue search scope and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Defender.jpeg              # Brand image / logo
 
 ## Versioning
 
+- **3.0.9** – Added “All Tabs” catalogue search scope and keyboard shortcuts (Enter adds first result, Esc clears or closes).
 - **3.0.8** – Fixed zero-quantity rows being counted as 1; qty=0 now contributes 0 to all totals and CSV round-trips correctly.
 - **3.0.7** – Prevented duplicate Section names (case-insensitive) to maintain clean CSV import/export integrity.
 - **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.8</title>
+  <title>DefCost 3.0.9</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -23,6 +23,16 @@ h1{margin:.2rem 0}p{margin:0 0 2rem}
 .search-cancel{display:none;padding:.35rem .75rem;border-radius:4px;border:1px solid var(--border);background:var(--header);color:var(--fg);cursor:pointer;font-weight:600;white-space:nowrap}
 .search-cancel:hover{filter:brightness(.96)}
 .search-cancel.visible{display:inline-flex}
+.search-scope-toggle{display:inline-flex;align-items:center;gap:.35rem;font-size:.9rem;color:var(--fg);opacity:.75;margin-left:auto;white-space:nowrap;cursor:pointer;user-select:none}
+.search-scope-toggle input{margin:0}
+.search-hint{font-size:.8rem;color:rgba(0,0,0,.6);margin:.2rem 0 .45rem}
+.dark-mode .search-hint{color:rgba(255,255,255,.65)}
+.catalogue-results-meta{font-size:.8rem;color:rgba(0,0,0,.65);margin-bottom:.35rem}
+.dark-mode .catalogue-results-meta{color:rgba(255,255,255,.6)}
+.catalogue-empty{padding:.6rem 0;color:rgba(0,0,0,.6);font-style:italic}
+.dark-mode .catalogue-empty{color:rgba(255,255,255,.65)}
+.catalogue-source-label{display:inline-flex;align-items:center;padding:0 .4rem;margin-top:.2rem;border-radius:999px;background:var(--header);color:var(--fg);font-size:.7rem;opacity:.8}
+.dark-mode .catalogue-source-label{background:#3d3d3d;color:#fff}
 .highlight{background:yellow}
 table{border-collapse:collapse;width:100%}
 thead th{position:sticky;top:0;background:var(--header);border:1px solid var(--border);padding:.5rem;text-align:center;z-index:2}
@@ -186,7 +196,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-        <h1>DefCost 3.0.8</h1>
+        <h1>DefCost 3.0.9</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">

--- a/js/catalogue.js
+++ b/js/catalogue.js
@@ -22,7 +22,8 @@
       x: maxX,
       y: y,
       w: width,
-      h: height
+      h: height,
+      scope: 'current'
     };
   }
 
@@ -36,7 +37,8 @@
       x: parseFloat(raw.x),
       y: parseFloat(raw.y),
       w: parseFloat(raw.w),
-      h: parseFloat(raw.h)
+      h: parseFloat(raw.h),
+      scope: raw.scope === 'all' ? 'all' : 'current'
     };
     if(!isFinite(next.w) || next.w < 320) next.w = defaults.w;
     next.w = Math.min(Math.max(320, next.w), winW || next.w);
@@ -58,6 +60,7 @@
     state.y = normalized.y;
     state.w = normalized.w;
     state.h = normalized.h;
+    state.scope = normalized.scope;
     return normalized;
   }
 
@@ -109,7 +112,8 @@
         x: Math.round(isFinite(normalized.x) ? normalized.x : 0),
         y: Math.round(isFinite(normalized.y) ? normalized.y : 0),
         w: Math.round(isFinite(normalized.w) ? normalized.w : 0),
-        h: Math.round(isFinite(normalized.h) ? normalized.h : 0)
+        h: Math.round(isFinite(normalized.h) ? normalized.h : 0),
+        scope: normalized.scope === 'all' ? 'all' : 'current'
       }));
     }catch(e){}
     return normalized;


### PR DESCRIPTION
## Summary
- add an "All Tabs" scope toggle for the catalogue search with tab labels on results and persist its state
- wire Enter/Esc shortcuts and autofocus for the catalogue search input plus UX hints and messaging
- update styling assets and version metadata to DefCost 3.0.9 with a changelog entry

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f073c5b0a08327b29c14727de514ef