### PR TITLE
Add catalogue all-tabs mode and keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Defender.jpeg              # Brand image / logo
 
 ## Versioning
 
+- **3.0.9** – Added 'All tabs' catalogue switch, Enter-to-add-first-result, and ⌘K/Ctrl+K catalogue toggle with persisted state.
 - **3.0.8** – Fixed zero-quantity rows being counted as 1; qty=0 now contributes 0 to all totals and CSV round-trips correctly.
 - **3.0.7** – Prevented duplicate Section names (case-insensitive) to maintain clean CSV import/export integrity.
 - **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.8</title>
+  <title>DefCost 3.0.9</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -23,6 +23,20 @@ h1{margin:.2rem 0}p{margin:0 0 2rem}
 .search-cancel{display:none;padding:.35rem .75rem;border-radius:4px;border:1px solid var(--border);background:var(--header);color:var(--fg);cursor:pointer;font-weight:600;white-space:nowrap}
 .search-cancel:hover{filter:brightness(.96)}
 .search-cancel.visible{display:inline-flex}
+.all-tabs-control{display:flex;align-items:center;gap:.4rem;margin-left:auto;flex:0 0 auto}
+.all-tabs-text{font-weight:600;font-size:.9rem}
+.all-tabs-switch{position:relative;display:inline-flex;align-items:center;justify-content:flex-start;width:36px;height:20px;border-radius:999px;border:1px solid var(--border);background:var(--header);padding:0;cursor:pointer;transition:.2s;color:inherit}
+.all-tabs-switch:hover{filter:brightness(.96)}
+.all-tabs-switch-thumb{width:16px;height:16px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.25);transform:translateX(2px);transition:.2s}
+.all-tabs-switch.on{background:var(--btn);border-color:var(--btn)}
+.all-tabs-switch.on .all-tabs-switch-thumb{transform:translateX(16px);background:#fff}
+.dark-mode .all-tabs-switch{background:#3a3a3a;border-color:#555}
+.dark-mode .all-tabs-switch.on{background:var(--btn);border-color:var(--btn)}
+.dark-mode .all-tabs-switch-thumb{background:#f0f0f0}
+.catalogue-tab-badge{display:inline-flex;align-items:center;margin-left:.4rem;padding:.1rem .45rem;border-radius:999px;background:var(--header);color:var(--fg);font-size:.75rem;font-weight:600;line-height:1.2}
+.dark-mode .catalogue-tab-badge{background:#3a3a3a;color:#f1f1f1}
+.catalogue-empty{margin:.6rem 0;font-size:.95rem;opacity:.8}
+.catalogue-limit-note{margin:.5rem 0 0;font-size:.85rem;opacity:.75}
 .highlight{background:yellow}
 table{border-collapse:collapse;width:100%}
 thead th{position:sticky;top:0;background:var(--header);border:1px solid var(--border);padding:.5rem;text-align:center;z-index:2}
@@ -186,7 +200,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-        <h1>DefCost 3.0.8</h1>
+        <h1>DefCost 3.0.9</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">

--- a/js/catalogue.js
+++ b/js/catalogue.js
@@ -1,9 +1,10 @@
+import { loadCatalogueState, saveCatalogueState } from './storage.js';
+
 (function(){
   window.DefCost = window.DefCost || {};
   window.DefCost.state = window.DefCost.state || {};
   var state = window.DefCost.state.catalogue = window.DefCost.state.catalogue || {};
   var api = window.DefCost.catalogue = window.DefCost.catalogue || {};
-  var STORAGE_KEY = 'defcost_catalogue_state';
 
   function getDefaultState(){
     var winW = window.innerWidth || 1200;
@@ -22,7 +23,8 @@
       x: maxX,
       y: y,
       w: width,
-      h: height
+      h: height,
+      allTabs: false
     };
   }
 
@@ -36,7 +38,8 @@
       x: parseFloat(raw.x),
       y: parseFloat(raw.y),
       w: parseFloat(raw.w),
-      h: parseFloat(raw.h)
+      h: parseFloat(raw.h),
+      allTabs: typeof raw.allTabs === 'boolean' ? raw.allTabs : defaults.allTabs
     };
     if(!isFinite(next.w) || next.w < 320) next.w = defaults.w;
     next.w = Math.min(Math.max(320, next.w), winW || next.w);
@@ -58,6 +61,24 @@
     state.y = normalized.y;
     state.w = normalized.w;
     state.h = normalized.h;
+    state.allTabs = !!normalized.allTabs;
+    state.visibleResults = Array.isArray(state.visibleResults) ? state.visibleResults : [];
+    state.addFirstHandler = typeof state.addFirstHandler === 'function' ? state.addFirstHandler : null;
+    return normalized;
+  }
+
+  function persistCatalogueState(raw){
+    var normalized = syncState(raw || state);
+    try{
+      saveCatalogueState({
+        isOpen: normalized.isOpen,
+        x: normalized.x,
+        y: normalized.y,
+        w: normalized.w,
+        h: normalized.h,
+        allTabs: normalized.allTabs
+      });
+    }catch(e){}
     return normalized;
   }
 
@@ -101,27 +122,14 @@
     qbWindow.style.height = current.h ? current.h + 'px' : '';
   }
 
-  api.persistState = function(opts){
-    var normalized = syncState(state);
-    try{
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({
-        isOpen: normalized.isOpen,
-        x: Math.round(isFinite(normalized.x) ? normalized.x : 0),
-        y: Math.round(isFinite(normalized.y) ? normalized.y : 0),
-        w: Math.round(isFinite(normalized.w) ? normalized.w : 0),
-        h: Math.round(isFinite(normalized.h) ? normalized.h : 0)
-      }));
-    }catch(e){}
-    return normalized;
+  api.persistState = function(){
+    return persistCatalogueState(state);
   };
 
   api.restoreState = function(opts){
     var stored = null;
     try{
-      var raw = localStorage.getItem(STORAGE_KEY);
-      if(raw){
-        stored = JSON.parse(raw);
-      }
+      stored = loadCatalogueState();
     }catch(e){}
     var normalized = syncState(stored);
     applyDisplay(normalized, Object.assign({}, opts, { skipPosition: true }));
@@ -139,7 +147,7 @@
     applyDisplay(normalized, opts);
     applyPosition(normalized, opts);
     if(!opts.skipSave){
-      api.persistState(opts);
+      persistCatalogueState(normalized);
     }
     return state;
   };
@@ -153,8 +161,60 @@
     }
     applyDisplay(normalized, Object.assign({}, opts, { skipPosition: true }));
     if(!opts.skipSave){
-      api.persistState(opts);
+      persistCatalogueState(normalized);
     }
     return state;
+  };
+
+  api.isAllTabsEnabled = function(){
+    return !!state.allTabs;
+  };
+
+  api.setAllTabs = function(next, opts){
+    var target = !!next;
+    var normalized = syncState(Object.assign({}, state, { allTabs: target }));
+    state.allTabs = normalized.allTabs;
+    if(!opts || !opts.skipSave){
+      persistCatalogueState(normalized);
+    }
+    return state.allTabs;
+  };
+
+  api.toggleAllTabs = function(opts){
+    return api.setAllTabs(!state.allTabs, opts);
+  };
+
+  api.setVisibleResults = function(results){
+    state.visibleResults = Array.isArray(results) ? results.slice(0) : [];
+    return state.visibleResults;
+  };
+
+  api.getVisibleResults = function(){
+    return Array.isArray(state.visibleResults) ? state.visibleResults.slice(0) : [];
+  };
+
+  api.registerAddFirstHandler = function(handler){
+    state.addFirstHandler = typeof handler === 'function' ? handler : null;
+  };
+
+  api.addFirstVisibleResult = function(){
+    var list = Array.isArray(state.visibleResults) ? state.visibleResults : [];
+    if(!list.length){
+      return false;
+    }
+    var first = list[0];
+    if(first && typeof first.onAdd === 'function'){
+      first.onAdd();
+      return true;
+    }
+    if(state.addFirstHandler){
+      try{
+        state.addFirstHandler(first);
+        return true;
+      }catch(e){
+        return false;
+      }
+    }
+    return false;
   };
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -40,6 +40,7 @@ const showImportSummaryModal = typeof uiNamespace.showImportSummaryModal === 'fu
 const showToast = typeof uiNamespace.showToast === 'function'
   ? uiNamespace.showToast
   : function () {};
+const isMacPlatform = /Mac|iPod|iPhone|iPad/.test((navigator.platform || navigator.userAgent || '').toString());
 
 (function(){
 function bindUiState(){
@@ -91,6 +92,7 @@ var FALL=META["uncategorised"];
 var PRICE_EX=["Rate Ex. GST","Price Ex. GST","Price","Price Ex Tax","Price ex GST"];
 var UNDO_TOAST_MS=60000;
 var wb=null,basket=[],sections=getDefaultSections(),uid=0,sectionSeq=1,activeSectionId=sections[0].id,captureParentId=null;
+var sheetCache={},sheetNames=[];
 var tabs=document.getElementById("sheetTabs"),container=document.getElementById("sheetContainer"),sectionTabsEl=document.getElementById("sectionTabs"),grandTotalsEl=document.getElementById("grandTotals"),grandTotalsWrap=document.querySelector('.grand-totals-wrapper');
 var discountPercent=0,currentGrandTotal=0,lastBaseTotal=0,grandTotalsUi=null,latestReport=null;
 var qbWindow=document.getElementById('catalogWindow'),qbTitlebar=document.getElementById('catalogTitlebar'),qbDockIcon=document.getElementById('catalogDockIcon'),qbMin=document.getElementById('catalogMin'),qbClose=document.getElementById('catalogClose'),qbZoom=document.getElementById('catalogZoom'),qbResizeHandle=document.getElementById('catalogResizeHandle');
@@ -101,6 +103,7 @@ if(typeof qbState.isOpen==='undefined')qbState.isOpen=true;
 qbState.full=!!qbState.full;
 qbState.docked=!!qbState.docked;
 if(!isFinite(qbState.dockHeight))qbState.dockHeight=getDefaultDockHeight();
+if(typeof qbState.allTabs==='undefined')qbState.allTabs=false;
 var lastFreeRect=cloneRect(qbState);
 if(!lastFreeRect.w||!lastFreeRect.h){lastFreeRect=cloneRect(defaultUiState());}
 var dragInfo=null,resizeInfo=null,prevUserSelect='';
@@ -148,6 +151,23 @@ document.addEventListener('keydown',function(ev){
    if((ev.metaKey||ev.ctrlKey)&&!ev.altKey&&!ev.shiftKey&&(ev.key==='f'||ev.key==='F')){
      ev.preventDefault();
      focusSearchField();
+     return;
+   }
+   if(!ev.altKey&&!ev.shiftKey&&(ev.key==='k'||ev.key==='K')&&((isMacPlatform&&ev.metaKey)||(!isMacPlatform&&ev.ctrlKey))){
+     if(document.querySelector('.qb-modal-backdrop, .import-summary-backdrop')){
+       return;
+     }
+     ev.preventDefault();
+     var isOpenNow=qbState&&qbState.isOpen!==false;
+     if(isOpenNow){
+       setMinimized(true);
+       if(qbWindow&&qbWindow.contains(document.activeElement||null)){
+         try{(document.activeElement||{}).blur();}catch(e){}
+       }
+     }else{
+       setMinimized(false);
+       setTimeout(function(){focusSearchField();},0);
+     }
      return;
    }
    if(ev.key==='Escape'||ev.key==='Esc'){
@@ -664,12 +684,383 @@ var statusEl=document.getElementById('status');var pickerWrap=document.getElemen
 function showStatus(html){if(statusEl){statusEl.innerHTML=html;}}
 function showPicker(reason){showStatus('<span style="color:#b00">Couldn\'t load <code>Defender Price List.xlsx</code> ('+reason+').</span> You can upload the workbook manually below.');if(pickerWrap)pickerWrap.style.display='block';}
 function whenXLSXReady(cb){if(window.XLSX){cb();return;}var s=document.querySelector('script[data-sheetjs]');if(!s){s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/xlsx@0.20.3/dist/xlsx.full.min.js';s.setAttribute('data-sheetjs','1');s.onload=function(){cb()};s.onerror=function(){showPicker('SheetJS failed to load')};document.head.appendChild(s);}else{var tries=0;var t=setInterval(function(){if(window.XLSX){clearInterval(t);cb();}else if(++tries>50){clearInterval(t);showPicker('SheetJS failed to load');}},100);}}
-function parseAndBuild(buf){try{wb=XLSX.read(buf,{type:'array'});}catch(e){console.error(e);showPicker('invalid file');return;}var names=Object.keys(wb.Sheets||{});if(!names.length){showPicker('workbook has no sheets');return;}tabs.innerHTML='';container.innerHTML='';showStatus('');if(pickerWrap)pickerWrap.style.display='none';for(var i=0;i<names.length;i++){(function(name,idx){var b=document.createElement('button');b.textContent=name;b.dataset.sheet=name;b.onclick=function(){active(name);draw(name)};if(idx===0){b.classList.add('active');draw(name);}tabs.appendChild(b);})(names[i],i);} }
+function parseAndBuild(buf){try{wb=XLSX.read(buf,{type:'array'});}catch(e){console.error(e);showPicker('invalid file');return;}var names=Object.keys(wb.Sheets||{});if(!names.length){showPicker('workbook has no sheets');return;}sheetCache={};sheetNames=names.slice();tabs.innerHTML='';container.innerHTML='';showStatus('');if(pickerWrap)pickerWrap.style.display='none';if(catalogueNamespace&&typeof catalogueNamespace.setVisibleResults==='function'){catalogueNamespace.setVisibleResults([]);}for(var i=0;i<names.length;i++){(function(name,idx){var b=document.createElement('button');b.textContent=name;b.dataset.sheet=name;b.onclick=function(){active(name);draw(name)};if(idx===0){b.classList.add('active');draw(name);}tabs.appendChild(b);})(names[i],i);} }
 window.addEventListener('error',function(e){showStatus("<span style='color:#b00'>Error:</span> "+e.message)});
 showStatus('Loading <code>Defender Price List.xlsx</code>…');
 fetch('./Defender%20Price%20List.xlsx',{cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer();}).then(function(buf){whenXLSXReady(function(){parseAndBuild(buf);});}).catch(function(err){console.error(err);showPicker(err.message||'network error');});
 if(picker){picker.addEventListener('change',function(e){var tgt=e&&e.target;var files=tgt&&tgt.files;var f=files&&files[0];if(!f)return;if(f.arrayBuffer){f.arrayBuffer().then(function(ab){whenXLSXReady(function(){parseAndBuild(ab);});});}else{var reader=new FileReader();reader.onload=function(ev){var ab=ev.target.result;whenXLSXReady(function(){parseAndBuild(ab);});};reader.readAsArrayBuffer(f);}});} 
-function draw(name){if(!wb||!wb.Sheets||!wb.Sheets[name]){container.textContent='No such sheet.';return;}var rows=XLSX.utils.sheet_to_json(wb.Sheets[name],{header:1,defval:""});if(!rows.length){container.textContent='Empty sheet.';return;}var header=rows[0].map(function(h){return String(h).trim();});var catIdx=header.indexOf("Category");if(catIdx===-1){container.textContent='No "Category" column in this sheet.';return;}var body=rows.slice(1);container.innerHTML="";var sDiv=document.createElement("div");sDiv.className="search-container";var label=document.createElement("label");label.className="search-label";var searchId='catalogSearch_'+Date.now();label.setAttribute('for',searchId);label.textContent='Search items:';var control=document.createElement("div");control.className="search-control";var inp=document.createElement("input");inp.className="search-input";inp.type='search';inp.id=searchId;inp.placeholder='Type to filter...';var cancelBtn=document.createElement("button");cancelBtn.type='button';cancelBtn.className='search-cancel';cancelBtn.textContent='Cancel';control.appendChild(inp);control.appendChild(cancelBtn);sDiv.appendChild(label);sDiv.appendChild(control);container.appendChild(sDiv);var wrap=document.createElement("div");container.appendChild(wrap);currentSearchInput=inp;function updateCancel(){if(!cancelBtn)return;var hasValue=!!inp.value;cancelBtn.classList.toggle('visible',hasValue);}function handleInput(){updateCancel();render();}inp.addEventListener('input',handleInput);inp.addEventListener('keydown',function(e){if(e.key==='Escape'||e.key==='Esc'){if(inp.value){inp.value='';updateCancel();render();}e.stopPropagation();}});cancelBtn.addEventListener('click',function(){inp.value='';updateCancel();render();try{inp.focus({preventScroll:true});}catch(e){inp.focus();}});updateCancel();render();function render(){updateCancel();var term=(inp.value||"").toLowerCase();wrap.innerHTML="";var groups={};for(var i=0;i<body.length;i++){var r=body[i];if(term){var match=false;for(var j=0;j<r.length;j++){if(String(r[j]).toLowerCase().indexOf(term)>-1){match=true;break;}}if(!match)continue;}var cat=(r[catIdx]||"Uncategorised").toString().trim();if(!groups[cat])groups[cat]=[];groups[cat].push(r);}var cats=Object.keys(groups).sort(function(a,b){var A=(META[a.toLowerCase()]||FALL).idx;var B=(META[b.toLowerCase()]||FALL).idx;return A-B;});for(var c=0;c<cats.length;c++){(function(cat){var cls=(META[cat.toLowerCase()]||FALL).cls;var det=document.createElement("details");det.open=!!term;det.className=cls;var sum=document.createElement("summary");sum.textContent=cat;det.appendChild(sum);var tbl=document.createElement("table");var ths=header.filter(function(_,i){return i!==catIdx;}).map(function(h){return '<th>'+h+'</th>';}).join("");tbl.innerHTML='<thead><tr><th></th>'+ths+'</tr></thead>';var tbody=document.createElement("tbody");tbl.appendChild(tbody);var items=groups[cat];for(var r=0;r<items.length;r++){(function(row){var tr=document.createElement("tr");var tdAdd=document.createElement("td");var btn=document.createElement("button");btn.className="add-button";btn.textContent="+";btn.onclick=function(){addItem(row,header);};tdAdd.appendChild(btn);tr.appendChild(tdAdd);for(var i2=0;i2<row.length;i2++){if(i2===catIdx)continue;var td=document.createElement("td");var h=(header[i2]||"").toLowerCase();var txt=/price|gst|rate/.test(h)&&!isNaN(row[i2])?(+row[i2]).toFixed(2):row[i2];if(term){try{td.innerHTML=String(txt).replace(new RegExp('('+term+')','gi'),'<span class="highlight">$1</span>');}catch(e){td.textContent=String(txt);}}else{td.textContent=String(txt);}if(/price|gst|rate/.test(h))td.style.fontWeight="bold";td.onclick=function(e){if(e.target&&e.target.tagName==='BUTTON')return;var el=e.currentTarget;navigator.clipboard.writeText(el.textContent).then(function(){el.classList.add("copied-cell");void el.offsetWidth;setTimeout(function(){el.classList.remove("copied-cell");},150);}).catch(function(){});};tr.appendChild(td);}tbody.appendChild(tr);})(items[r]);}det.appendChild(tbl);wrap.appendChild(det);})(cats[c]);}}}
+
+function ensureSheetData(name){
+  if(!wb||!wb.Sheets||!wb.Sheets[name]) return null;
+  if(sheetCache[name]) return sheetCache[name];
+  var rows=[];
+  try{
+    rows=XLSX.utils.sheet_to_json(wb.Sheets[name],{header:1,defval:""});
+  }catch(e){
+    sheetCache[name]={header:[],body:[],catIdx:-1,error:'Unable to read sheet.'};
+    return sheetCache[name];
+  }
+  if(!rows.length){
+    var emptyData={header:[],body:[],catIdx:-1,empty:true};
+    sheetCache[name]=emptyData;
+    return emptyData;
+  }
+  var header=rows[0].map(function(h){return String(h).trim();});
+  var catIdx=header.indexOf('Category');
+  if(catIdx===-1){
+    var errData={header:header,body:[],catIdx:-1,error:'No "Category" column in this sheet.'};
+    sheetCache[name]=errData;
+    return errData;
+  }
+  var body=rows.slice(1);
+  var data={header:header,body:body,catIdx:catIdx};
+  sheetCache[name]=data;
+  return data;
+}
+
+function getItemColumnIndex(header){
+  if(!Array.isArray(header)) return -1;
+  for(var i=0;i<header.length;i++){
+    var key=String(header[i]||'').toLowerCase();
+    if(key==='item'||key==='service / item'||key==='service') return i;
+  }
+  return -1;
+}
+
+function buildHighlightRegex(term){
+  if(!term) return null;
+  try{
+    return new RegExp('('+term+')','gi');
+  }catch(e){
+    return null;
+  }
+}
+
+
+function draw(name){
+  if(!wb||!wb.Sheets||!wb.Sheets[name]){
+    container.textContent='No such sheet.';
+    if(catalogueNamespace&&typeof catalogueNamespace.setVisibleResults==='function'){catalogueNamespace.setVisibleResults([]);}
+    return;
+  }
+  if(!sheetNames||!sheetNames.length){
+    sheetNames=Object.keys(wb.Sheets||{});
+  }
+  container.innerHTML='';
+  var sDiv=document.createElement('div');
+  sDiv.className='search-container';
+  var label=document.createElement('label');
+  label.className='search-label';
+  var searchId='catalogSearch_'+Date.now();
+  label.setAttribute('for',searchId);
+  label.textContent='Search items:';
+  var control=document.createElement('div');
+  control.className='search-control';
+  var inp=document.createElement('input');
+  inp.className='search-input';
+  inp.type='search';
+  inp.id=searchId;
+  inp.placeholder='Type to filter...';
+  var cancelBtn=document.createElement('button');
+  cancelBtn.type='button';
+  cancelBtn.className='search-cancel';
+  cancelBtn.textContent='Cancel';
+  control.appendChild(inp);
+  control.appendChild(cancelBtn);
+  sDiv.appendChild(label);
+  sDiv.appendChild(control);
+  var switchWrap=document.createElement('div');
+  switchWrap.className='all-tabs-control';
+  var switchText=document.createElement('span');
+  switchText.className='all-tabs-text';
+  switchText.textContent='All tabs';
+  var switchBtn=document.createElement('button');
+  switchBtn.type='button';
+  switchBtn.className='all-tabs-switch';
+  switchBtn.setAttribute('role','switch');
+  switchBtn.setAttribute('aria-label','All tabs');
+  switchBtn.title='Toggle all tabs';
+  var switchThumb=document.createElement('span');
+  switchThumb.className='all-tabs-switch-thumb';
+  switchBtn.appendChild(switchThumb);
+  switchWrap.appendChild(switchText);
+  switchWrap.appendChild(switchBtn);
+  sDiv.appendChild(switchWrap);
+  container.appendChild(sDiv);
+  var wrap=document.createElement('div');
+  wrap.className='catalogue-results';
+  container.appendChild(wrap);
+  currentSearchInput=inp;
+  var renderTimer=null;
+  function updateSwitchVisual(){
+    var on=catalogueNamespace&&typeof catalogueNamespace.isAllTabsEnabled==='function'?catalogueNamespace.isAllTabsEnabled():!!(window.DefCost&&window.DefCost.state&&window.DefCost.state.catalogue&&window.DefCost.state.catalogue.allTabs);
+    switchBtn.setAttribute('aria-checked',on?'true':'false');
+    switchBtn.classList.toggle('on',!!on);
+  }
+  function updateCancel(){
+    if(!cancelBtn)return;
+    cancelBtn.classList.toggle('visible',!!inp.value);
+  }
+  function showMessage(text){
+    var msg=document.createElement('p');
+    msg.className='catalogue-empty';
+    msg.textContent=text;
+    wrap.appendChild(msg);
+  }
+  function attachCopyHandler(td){
+    td.onclick=function(e){
+      if(e.target&&e.target.tagName==='BUTTON')return;
+      var text=(td.textContent||'').trim();
+      if(!text)return;
+      navigator.clipboard.writeText(text).then(function(){
+        td.classList.add('copied-cell');
+        void td.offsetWidth;
+        setTimeout(function(){td.classList.remove('copied-cell');},150);
+      }).catch(function(){});
+    };
+  }
+  function render(){
+    updateSwitchVisual();
+    updateCancel();
+    var sheetData=ensureSheetData(name)||{header:[],body:[],catIdx:-1};
+    var termRaw=inp.value||'';
+    var term=termRaw.toLowerCase();
+    var highlightRegex=buildHighlightRegex(term);
+    wrap.innerHTML='';
+    var visibleResults=[];
+    var allTabsOn=catalogueNamespace&&typeof catalogueNamespace.isAllTabsEnabled==='function'?catalogueNamespace.isAllTabsEnabled():false;
+    if(allTabsOn){
+      var headerOrder=[];
+      var headerSeen={};
+      var aggregated=[];
+      var trimmed=false;
+      for(var si=0;si<sheetNames.length;si++){
+        var tabName=sheetNames[si];
+        var tabData=ensureSheetData(tabName);
+        if(!tabData||tabData.error)continue;
+        var colIndexMap={};
+        for(var hi=0;hi<tabData.header.length;hi++){
+          if(hi===tabData.catIdx)continue;
+          var headerLabel=tabData.header[hi];
+          colIndexMap[headerLabel]=hi;
+          if(!headerSeen[headerLabel]){
+            headerSeen[headerLabel]=true;
+            headerOrder.push(headerLabel);
+          }
+        }
+        var itemCol=getItemColumnIndex(tabData.header);
+        var itemHeader=itemCol!==-1?tabData.header[itemCol]:headerOrder[0]||null;
+        for(var ri=0;ri<tabData.body.length;ri++){
+          var row=tabData.body[ri];
+          if(term){
+            var match=false;
+            for(var ci=0;ci<row.length;ci++){
+              if(ci===tabData.catIdx)continue;
+              if(String(row[ci]).toLowerCase().indexOf(term)>-1){match=true;break;}
+            }
+            if(!match&&String(tabName).toLowerCase().indexOf(term)>-1){match=true;}
+            if(!match)continue;
+          }
+          aggregated.push({tab:tabName,header:tabData.header,row:row,catIdx:tabData.catIdx,colIndexMap:colIndexMap,itemHeader:itemHeader});
+        }
+      }
+      if(aggregated.length>500){
+        aggregated=aggregated.slice(0,500);
+        trimmed=true;
+      }
+      if(!aggregated.length){
+        if(term){showMessage('No items found.');}
+        else if(sheetData.error){showMessage(sheetData.error);}
+        else{showMessage('No items available.');}
+      }else{
+        var tbl=document.createElement('table');
+        var thead=document.createElement('thead');
+        var headRow=document.createElement('tr');
+        headRow.appendChild(document.createElement('th'));
+        for(var hh=0;hh<headerOrder.length;hh++){
+          var th=document.createElement('th');
+          th.textContent=headerOrder[hh];
+          headRow.appendChild(th);
+        }
+        thead.appendChild(headRow);
+        tbl.appendChild(thead);
+        var tbody=document.createElement('tbody');
+        tbl.appendChild(tbody);
+        for(var ai=0;ai<aggregated.length;ai++){
+          (function(item){
+            var tr=document.createElement('tr');
+            var tdAdd=document.createElement('td');
+            var btn=document.createElement('button');
+            btn.className='add-button';
+            btn.textContent='+';
+            btn.onclick=function(){addItem(item.row,item.header);};
+            tdAdd.appendChild(btn);
+            tr.appendChild(tdAdd);
+            for(var hh2=0;hh2<headerOrder.length;hh2++){
+              var headerName=headerOrder[hh2];
+              var td=document.createElement('td');
+              var idx=item.colIndexMap.hasOwnProperty(headerName)?item.colIndexMap[headerName]:-1;
+              var rawValue=idx>-1?item.row[idx]:'';
+              var headerLower=String(headerName||'').toLowerCase();
+              var display=/price|gst|rate/.test(headerLower)&&!isNaN(rawValue)?(+rawValue).toFixed(2):rawValue;
+              if(highlightRegex){
+                try{td.innerHTML=String(display).replace(highlightRegex,'<span class="highlight">$1</span>');}
+                catch(e){td.textContent=String(display);}
+              }else{
+                td.textContent=String(display);
+              }
+              if(/price|gst|rate/.test(headerLower))td.style.fontWeight='bold';
+              if(item.itemHeader&&headerName===item.itemHeader){
+                var badge=document.createElement('span');
+                badge.className='catalogue-tab-badge';
+                badge.textContent=item.tab;
+                td.appendChild(badge);
+              }
+              attachCopyHandler(td);
+              tr.appendChild(td);
+            }
+            tbody.appendChild(tr);
+            visibleResults.push({row:item.row,header:item.header,tab:item.tab,onAdd:function(){addItem(item.row,item.header);}});
+          })(aggregated[ai]);
+        }
+        wrap.appendChild(tbl);
+        if(trimmed){
+          var note=document.createElement('div');
+          note.className='catalogue-limit-note';
+          note.textContent='Showing first 500 results.';
+          wrap.appendChild(note);
+        }
+      }
+    }else{
+      if(sheetData.error){
+        showMessage(sheetData.error);
+        if(catalogueNamespace&&typeof catalogueNamespace.setVisibleResults==='function'){catalogueNamespace.setVisibleResults([]);} 
+        return;
+      }
+      var groups={};
+      for(var i=0;i<sheetData.body.length;i++){
+        var row=sheetData.body[i];
+        if(term){
+          var match=false;
+          for(var j=0;j<row.length;j++){
+            if(j===sheetData.catIdx)continue;
+            if(String(row[j]).toLowerCase().indexOf(term)>-1){match=true;break;}
+          }
+          if(!match)continue;
+        }
+        var cat=(row[sheetData.catIdx]||'Uncategorised').toString().trim();
+        if(!groups[cat])groups[cat]=[];
+        groups[cat].push(row);
+      }
+      var cats=Object.keys(groups);
+      cats.sort(function(a,b){
+        var A=(META[a.toLowerCase()]||FALL).idx;
+        var B=(META[b.toLowerCase()]||FALL).idx;
+        return A-B;
+      });
+      if(!cats.length){
+        if(term){showMessage('No items found.');}
+        else if(sheetData.empty){showMessage('Empty sheet.');}
+        else{showMessage('No items available.');}
+      }else{
+        for(var c=0;c<cats.length;c++){
+          (function(cat){
+            var cls=(META[cat.toLowerCase()]||FALL).cls;
+            var det=document.createElement('details');
+            det.open=!!term;
+            det.className=cls;
+            var sum=document.createElement('summary');
+            sum.textContent=cat;
+            det.appendChild(sum);
+            var tbl=document.createElement('table');
+            var ths=sheetData.header.filter(function(_,idx){return idx!==sheetData.catIdx;}).map(function(h){return '<th>'+h+'</th>';}).join('');
+            tbl.innerHTML='<thead><tr><th></th>'+ths+'</tr></thead>';
+            var tbody=document.createElement('tbody');
+            tbl.appendChild(tbody);
+            var items=groups[cat];
+            for(var r=0;r<items.length;r++){
+              (function(row){
+                var tr=document.createElement('tr');
+                var tdAdd=document.createElement('td');
+                var btn=document.createElement('button');
+                btn.className='add-button';
+                btn.textContent='+';
+                btn.onclick=function(){addItem(row,sheetData.header);};
+                tdAdd.appendChild(btn);
+                tr.appendChild(tdAdd);
+                for(var i2=0;i2<row.length;i2++){
+                  if(i2===sheetData.catIdx)continue;
+                  var td=document.createElement('td');
+                  var headerLower=String(sheetData.header[i2]||'').toLowerCase();
+                  var val=/price|gst|rate/.test(headerLower)&&!isNaN(row[i2])?(+row[i2]).toFixed(2):row[i2];
+                  if(highlightRegex){
+                    try{td.innerHTML=String(val).replace(highlightRegex,'<span class="highlight">$1</span>');}
+                    catch(e){td.textContent=String(val);}
+                  }else{
+                    td.textContent=String(val);
+                  }
+                  if(/price|gst|rate/.test(headerLower))td.style.fontWeight='bold';
+                  attachCopyHandler(td);
+                  tr.appendChild(td);
+                }
+                tbody.appendChild(tr);
+                visibleResults.push({row:row,header:sheetData.header,tab:name,onAdd:function(){addItem(row,sheetData.header);}});
+              })(items[r]);
+            }
+            det.appendChild(tbl);
+            wrap.appendChild(det);
+          })(cats[c]);
+        }
+      }
+    }
+    if(catalogueNamespace&&typeof catalogueNamespace.setVisibleResults==='function'){
+      catalogueNamespace.setVisibleResults(visibleResults);
+    }
+  }
+  function queueRender(){
+    if(renderTimer){clearTimeout(renderTimer);}
+    renderTimer=setTimeout(render,200);
+  }
+  inp.addEventListener('input',queueRender);
+  inp.addEventListener('keydown',function(e){
+    if(e.key==='Escape'||e.key==='Esc'){
+      if(inp.value){
+        inp.value='';
+        updateCancel();
+        render();
+      }
+      e.stopPropagation();
+      return;
+    }
+    if(e.key==='Enter'){
+      e.preventDefault();
+      if(catalogueNamespace&&typeof catalogueNamespace.addFirstVisibleResult==='function'){
+        catalogueNamespace.addFirstVisibleResult();
+      }
+    }
+  });
+  cancelBtn.addEventListener('click',function(){
+    inp.value='';
+    updateCancel();
+    render();
+    try{inp.focus({preventScroll:true});}catch(e){inp.focus();}
+  });
+  switchBtn.addEventListener('click',function(){
+    var next=!((catalogueNamespace&&typeof catalogueNamespace.isAllTabsEnabled==='function')?catalogueNamespace.isAllTabsEnabled():!!(window.DefCost&&window.DefCost.state&&window.DefCost.state.catalogue&&window.DefCost.state.catalogue.allTabs));
+    if(catalogueNamespace&&typeof catalogueNamespace.setAllTabs==='function'){
+      catalogueNamespace.setAllTabs(next);
+    }else{
+      qbState.allTabs=next;
+    }
+    updateSwitchVisual();
+    render();
+    try{inp.focus({preventScroll:true});}catch(e){inp.focus();}
+  });
+  updateSwitchVisual();
+  updateCancel();
+  render();
+}
+
 var bBody=document.querySelector('#basketTable tbody'),bFoot=document.querySelector('#basketTable tfoot');
 bindUiState();
 if(bBody){

--- a/js/storage.js
+++ b/js/storage.js
@@ -10,6 +10,7 @@ import {
 
 export const LS_KEY = 'defcost_basket_v2';
 export const BACKUP_KEY = 'defcost_basket_backup';
+export const CATALOGUE_STATE_KEY = 'defcost_catalogue_state';
 export const IMPORT_HEADER = ['Section', 'Item', 'Quantity', 'Price', 'Line Total'];
 export const SUMMARY_ROWS = {
   'Total (Ex GST)': 1,
@@ -18,6 +19,57 @@ export const SUMMARY_ROWS = {
   'GST': 1,
   'Grand Total (Incl. GST)': 1
 };
+
+export function loadCatalogueState({
+  storageKey = CATALOGUE_STATE_KEY,
+  storage = window.localStorage
+} = {}) {
+  try {
+    const raw = storage.getItem(storageKey);
+    if (!raw) {
+      return null;
+    }
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== 'object') {
+      return null;
+    }
+    return data;
+  } catch (err) {
+    return null;
+  }
+}
+
+export function saveCatalogueState(state, {
+  storageKey = CATALOGUE_STATE_KEY,
+  storage = window.localStorage
+} = {}) {
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+  const payload = {
+    isOpen: !!state.isOpen,
+    x: Math.round(isFinite(state.x) ? state.x : 0),
+    y: Math.round(isFinite(state.y) ? state.y : 0),
+    w: Math.round(isFinite(state.w) ? state.w : 0),
+    h: Math.round(isFinite(state.h) ? state.h : 0),
+    allTabs: !!state.allTabs
+  };
+  if (typeof state.docked !== 'undefined') {
+    payload.docked = !!state.docked;
+  }
+  if (typeof state.full !== 'undefined') {
+    payload.full = !!state.full;
+  }
+  if (isFinite(state.dockHeight)) {
+    payload.dockHeight = Math.round(state.dockHeight);
+  }
+  try {
+    storage.setItem(storageKey, JSON.stringify(payload));
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
 
 export function saveBasket({
   basket,


### PR DESCRIPTION
## Summary
- add a persistent catalogue "All tabs" switch with merged results and tab badges
- allow pressing Enter in the search box to add the first visible result and expose helpers via the catalogue API
- add Cmd/Ctrl+K to toggle the catalogue, refresh styling, and bump the UI/readme version to 3.0.9

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68f07f574f24832793a3831c0a098cdb