### PR TITLE
Add All Tabs catalogue search scope and keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Defender.jpeg              # Brand image / logo
 
 ## Versioning
 
+- **3.0.9** – Added an “All Tabs” catalogue search scope with tab labels plus Enter-to-add and ⌘K / Ctrl+K catalogue shortcuts.
 - **3.0.8** – Fixed zero-quantity rows being counted as 1; qty=0 now contributes 0 to all totals and CSV round-trips correctly.
 - **3.0.7** – Prevented duplicate Section names (case-insensitive) to maintain clean CSV import/export integrity.
 - **3.0.6** – Hybrid modularisation C: Minimal catalogue module (open/close/state persistence). No functional changes.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.8</title>
+  <title>DefCost 3.0.9</title>
 <style>
 :root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
 .dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
@@ -23,6 +23,16 @@ h1{margin:.2rem 0}p{margin:0 0 2rem}
 .search-cancel{display:none;padding:.35rem .75rem;border-radius:4px;border:1px solid var(--border);background:var(--header);color:var(--fg);cursor:pointer;font-weight:600;white-space:nowrap}
 .search-cancel:hover{filter:brightness(.96)}
 .search-cancel.visible{display:inline-flex}
+.search-scope-toggle{display:inline-flex;align-items:center;gap:.35rem;margin-left:auto;font-size:.9rem;font-weight:600;opacity:.8;cursor:pointer;user-select:none;white-space:nowrap;color:var(--fg)}
+.search-scope-toggle input{width:16px;height:16px;margin:0}
+.search-hint{font-size:.8rem;color:rgba(0,0,0,.55);margin:.1rem 0 .2rem 0}
+.dark-mode .search-hint{color:rgba(255,255,255,.6)}
+.item-cell-stack{display:flex;flex-direction:column;align-items:flex-start;gap:.1rem}
+.item-cell-line{display:block}
+.tab-source-label{display:inline-flex;align-items:center;gap:.25rem;padding:.1rem .45rem;border-radius:999px;font-size:.7rem;font-weight:600;background:var(--header);color:var(--fg);opacity:.8;letter-spacing:.01em}
+.dark-mode .tab-source-label{background:#3a3a3a;color:#f5f5f5;opacity:.85}
+.search-results-note{font-size:.8rem;margin-top:.35rem;color:rgba(0,0,0,.6)}
+.dark-mode .search-results-note{color:rgba(255,255,255,.65)}
 .highlight{background:yellow}
 table{border-collapse:collapse;width:100%}
 thead th{position:sticky;top:0;background:var(--header);border:1px solid var(--border);padding:.5rem;text-align:center;z-index:2}
@@ -186,7 +196,7 @@ input[type=number]{-moz-appearance:textfield}
 </style>
 </head>
 <body>
-        <h1>DefCost 3.0.8</h1>
+        <h1>DefCost 3.0.9</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">

--- a/js/catalogue.js
+++ b/js/catalogue.js
@@ -22,7 +22,8 @@
       x: maxX,
       y: y,
       w: width,
-      h: height
+      h: height,
+      scope: 'current'
     };
   }
 
@@ -36,7 +37,8 @@
       x: parseFloat(raw.x),
       y: parseFloat(raw.y),
       w: parseFloat(raw.w),
-      h: parseFloat(raw.h)
+      h: parseFloat(raw.h),
+      scope: raw.scope === 'all' ? 'all' : 'current'
     };
     if(!isFinite(next.w) || next.w < 320) next.w = defaults.w;
     next.w = Math.min(Math.max(320, next.w), winW || next.w);
@@ -58,6 +60,7 @@
     state.y = normalized.y;
     state.w = normalized.w;
     state.h = normalized.h;
+    state.scope = normalized.scope;
     return normalized;
   }
 
@@ -109,7 +112,8 @@
         x: Math.round(isFinite(normalized.x) ? normalized.x : 0),
         y: Math.round(isFinite(normalized.y) ? normalized.y : 0),
         w: Math.round(isFinite(normalized.w) ? normalized.w : 0),
-        h: Math.round(isFinite(normalized.h) ? normalized.h : 0)
+        h: Math.round(isFinite(normalized.h) ? normalized.h : 0),
+        scope: normalized.scope === 'all' ? 'all' : 'current'
       }));
     }catch(e){}
     return normalized;


### PR DESCRIPTION
## Summary
- add an "All Tabs" search scope toggle with persistent state, tab labels, and large-result capping in the catalogue
- implement keyboard shortcuts (Enter to add first result, Esc clear/close, Cmd/Ctrl+K window toggle) and auto-focus search on open
- refresh catalogue styles and bump the displayed/README version to 3.0.9

## Testing
- Manually verified catalogue UI in browser (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68f0864a9eb88327825fbc72c0773bcd