### PR TITLE
DefCost 3.0.11 – extract inline styles into css/style.css

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,15 @@ Codex may continue to reference these globals for coordination until a full ES6 
 
 ---
 
+## CSS Architecture (3.0.11+)
+
+- `/css/style.css` is the single source for layout, spacing, borders, typography, and colour tokens.
+- `index.html` must reference these styles via classes/IDs; avoid reintroducing inline `style` attributes.
+- Dark/light theming relies on CSS variables with `.light` applied to `<body>` for the light variant (dark is default when `.light` is absent).
+- When editing UI or HTML, keep the class hooks in sync with `/css/style.css` so components remain pixel-perfect.
+
+---
+
 ## Versioning Rules
 
 Codex must update the **displayed project version** in both the UI header and `README.md` whenever a patch is applied.  

--- a/README.md
+++ b/README.md
@@ -88,17 +88,27 @@ Defender.jpeg              # Brand image / logo
 
 ## Current Status
 
-- Implemented: **Sections, sub-items, and per-section notes** with persistence  
-- Implemented: **Quote Builder** as main workspace  
-- Implemented: **Catalogue** in floating macOS-style window  
-- Implemented: **Window controls** (delete quote modal, minimise, dock icon, full-screen toggle)  
-- Implemented: **Import Summary modal** and Undo system after CSV import  
+- Implemented: **Sections, sub-items, and per-section notes** with persistence
+- Implemented: **Quote Builder** as main workspace
+- Implemented: **Catalogue** in floating macOS-style window
+- Implemented: **Window controls** (delete quote modal, minimise, dock icon, full-screen toggle)
+- Implemented: **Import Summary modal** and Undo system after CSV import
 - Implemented: **Hybrid modular JS architecture** (main, ui, storage, calc, catalogue)
+
+---
+
+## 3.0.11 – CSS architecture introduced
+
+- Added `/css/style.css` as the single design layer for layout, spacing, and colour tokens.
+- Refactored `index.html` to remove inline styles in favour of reusable class hooks.
+- Maintained pixel-perfect parity with 3.0.10 — no behavioural or visual changes.
+- Dark mode toggle now switches the `.light` class on `<body>`.
 
 ---
 
 ## Versioning
 
+- **3.0.11** – Technical CSS refactor: moved inline styling to `/css/style.css`, identical UI/behaviour; ensured dark-mode toggle compatibility and table alignment.
 - **3.0.10** – Removed redundant ‘Add note sub-item’ button; streamlined sub-item creation via ‘Capture catalogue adds as sub-item’ and ‘Add custom line’.
 - **3.0.9** – Added an “All Tabs” catalogue search scope with tab labels plus Enter-to-add and ⌘K / Ctrl+K catalogue shortcuts.
 - **3.0.8** – Fixed zero-quantity rows being counted as 1; qty=0 now contributes 0 to all totals and CSV round-trips correctly.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,1393 @@
+:root {
+  --bg: #222;
+  --fg: #eee;
+  --header: #444;
+  --btn: #0d6efd;
+  --btnh: #0a58ca;
+  --add: #198754;
+  --addh: #157347;
+  --border: #555;
+  --alt: #2a2a2a;
+  --panel: #333;
+  --toast: #0d6efd;
+  --toastfg: #fff;
+  --rowHover: #383838;
+  --font-family: sans-serif;
+  --shadow-panel: 0 16px 40px rgba(0, 0, 0, 0.18);
+  --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.35);
+  --shadow-catalog: 0 24px 80px rgba(0, 0, 0, 0.35);
+  --shadow-import: 0 25px 70px rgba(0, 0, 0, 0.55);
+}
+
+.light {
+  --bg: #f7f7f7;
+  --fg: #333;
+  --header: #e0e0e0;
+  --btn: #007bff;
+  --btnh: #0056b3;
+  --add: #28a745;
+  --addh: #218838;
+  --border: #aaa;
+  --alt: #f9f9f9;
+  --panel: #fff;
+  --toast: #007bff;
+  --toastfg: #fff;
+  --rowHover: #e9f1ff;
+  --shadow-panel: 0 16px 40px rgba(0, 0, 0, 0.18);
+  --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.35);
+  --shadow-catalog: 0 24px 80px rgba(0, 0, 0, 0.35);
+  --shadow-import: 0 25px 70px rgba(15, 23, 42, 0.35);
+}
+
+html, body {
+  min-height: 100%;
+}
+
+body {
+  font-family: var(--font-family);
+  margin: 1rem;
+  background: var(--bg);
+  color: var(--fg);
+  transition: 0.3s;
+}
+
+h1 {
+  margin: 0.2rem 0;
+}
+
+p {
+  margin: 0 0 2rem;
+}
+
+.hidden-input {
+  display: none;
+}
+
+#darkModeToggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 3000;
+  background: var(--btn);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#darkModeToggle:hover {
+  background: var(--btnh);
+}
+
+#sheetTabs {
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
+}
+
+#sheetTabs button {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  margin-right: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--fg);
+}
+
+#sheetTabs button.active {
+  border-bottom: 2px solid var(--btn);
+  font-weight: bold;
+}
+
+.search-container {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-label {
+  font-weight: bold;
+}
+
+.search-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 220px;
+}
+
+.search-input {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  flex: 1 1 auto;
+  background: var(--panel);
+  color: var(--fg);
+}
+
+.search-cancel {
+  display: none;
+  padding: 0.35rem 0.75rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--header);
+  color: var(--fg);
+  cursor: pointer;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.search-cancel:hover {
+  filter: brightness(0.96);
+}
+
+.search-cancel.visible {
+  display: inline-flex;
+}
+
+.search-scope-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
+  font-size: 0.9rem;
+  font-weight: 600;
+  opacity: 0.8;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  color: var(--fg);
+}
+
+.search-scope-toggle input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+}
+
+.search-hint {
+  font-size: 0.8rem;
+  margin: 0.1rem 0 0.2rem 0;
+}
+
+.item-cell-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1rem;
+}
+
+.item-cell-line {
+  display: block;
+}
+
+.tab-source-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.search-results-note {
+  font-size: 0.8rem;
+  margin-top: 0.35rem;
+}
+
+.highlight {
+  background: yellow;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  background: var(--header);
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  text-align: center;
+  z-index: 2;
+}
+
+tbody td {
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+}
+
+tbody tr {
+  background: var(--panel);
+}
+
+tbody tr:hover {
+  background: var(--rowHover);
+}
+
+.add-button {
+  background: var(--add);
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.add-button:hover {
+  background: var(--addh);
+}
+
+.copied-cell {
+  background: #c8e6c9 !important;
+  transition: 0.15s;
+}
+
+details {
+  margin-bottom: 1rem;
+}
+
+summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  background: var(--header);
+  font-weight: bold;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+summary:hover {
+  background: var(--btn);
+  color: #fff;
+}
+
+.cat-orange summary {
+  background: #ffe9d6;
+}
+
+.cat-orange summary:hover {
+  background: #ffc999;
+  color: #000;
+}
+
+.cat-blue summary {
+  background: #d8ebff;
+}
+
+.cat-blue summary:hover {
+  background: #add6ff;
+  color: #000;
+}
+
+.cat-brown summary {
+  background: #f2e6d9;
+}
+
+.cat-brown summary:hover {
+  background: #e0cbb9;
+  color: #000;
+}
+
+.cat-red summary {
+  background: #ffdede;
+}
+
+.cat-red summary:hover {
+  background: #ffb7b7;
+  color: #000;
+}
+
+.cat-yellow summary {
+  background: #fff8d6;
+}
+
+.cat-yellow summary:hover {
+  background: #ffea9f;
+  color: #000;
+}
+
+#quoteBuilderMain {
+  margin-top: 1.5rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-panel);
+  padding: 1rem 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#quoteHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.quote-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+#quoteHeader #qbTitle {
+  margin: 0;
+  font-size: 1.55rem;
+  font-weight: bold;
+}
+
+#quoteActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+#quoteActions button {
+  background: var(--btn);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+#quoteActions button:hover {
+  background: var(--btnh);
+}
+
+#catalogWindow {
+  position: fixed;
+  top: 64px;
+  right: 32px;
+  width: min(1100px, 90vw);
+  height: min(65vh, 80vh);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-catalog);
+  display: flex;
+  flex-direction: column;
+  z-index: 10000;
+  overflow: hidden;
+}
+
+#catalogWindow.qb-full {
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  border-radius: 0;
+}
+
+#catalogWindow.qb-docked {
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  width: auto;
+  max-width: none;
+  border-radius: 12px 12px 0 0;
+}
+
+#catalogWindow.qb-floating {
+  cursor: auto;
+}
+
+#catalogWindow.qb-docked #catalogTitlebar {
+  cursor: default;
+}
+
+#catalogResizeHandle {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  right: 0;
+  bottom: 0;
+  cursor: se-resize;
+  display: none;
+}
+
+#catalogResizeHandle::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-right: 2px solid rgba(0, 0, 0, 0.2);
+  border-bottom: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 2px;
+}
+
+#catalogWindow.qb-floating #catalogResizeHandle {
+  display: block;
+}
+
+#catalogWindow.qb-full #catalogResizeHandle,
+#catalogWindow.qb-docked #catalogResizeHandle {
+  display: none;
+}
+
+#catalogTitlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--header);
+  border-bottom: 1px solid var(--border);
+  cursor: move;
+  user-select: none;
+}
+
+#catalogDots {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#catalogDots button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 0;
+  cursor: pointer;
+}
+
+#catalogClose {
+  background: #ff5f57;
+}
+
+#catalogMin {
+  background: #ffbd2e;
+}
+
+#catalogZoom {
+  background: #28c840;
+}
+
+#catalogTitle {
+  flex: 1;
+  font-weight: bold;
+}
+
+#catalogBody {
+  flex: 1;
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
+  padding: 0 1rem 1rem;
+}
+
+#catalogDockIcon {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  display: none;
+  border-radius: 999px;
+  padding: 0.5rem 0.8rem;
+  background: var(--btn);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  z-index: 10001;
+}
+
+#catalogDockIcon:hover {
+  background: var(--btnh);
+}
+
+.qb-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10002;
+  padding: 1rem;
+}
+
+.qb-modal {
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-modal);
+  max-width: 420px;
+  width: 100%;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.qb-modal h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.qb-modal p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.qb-modal-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.qb-modal-buttons button {
+  background: var(--btn);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.qb-modal-buttons button:hover {
+  background: var(--btnh);
+}
+
+.qb-modal-buttons .danger {
+  background: #dc3545;
+}
+
+.qb-modal-buttons .danger:hover {
+  background: #bb2d3b;
+}
+
+.qb-modal-buttons .neutral {
+  background: var(--header);
+  color: var(--fg);
+}
+
+.qb-modal-buttons .neutral:hover {
+  filter: brightness(0.95);
+}
+
+#basketContainer {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  gap: 0;
+}
+
+#basketContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--panel);
+}
+
+.basket-table-area {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.grand-totals-wrapper {
+  display: none;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+#grandTotals {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  display: none;
+  font-weight: 600;
+  width: min(320px, 100%);
+  max-width: 340px;
+}
+
+#sectionTabsBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.45rem 0.65rem;
+  min-height: 48px;
+  background: var(--header);
+  border: 1px solid var(--border);
+  border-bottom: 0;
+  border-radius: 8px 8px 0 0;
+}
+
+#sectionTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.section-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.section-tab.active {
+  background: var(--btn);
+  color: #fff;
+  border-color: var(--btn);
+}
+
+.section-tab button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.section-tab button:hover {
+  opacity: 0.85;
+}
+
+#sectionTabs .section-name {
+  max-width: 160px;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#addSectionBtn {
+  background: var(--add);
+  color: #fff;
+  border: none;
+  padding: 0.35rem 0.7rem;
+  border-radius: 6px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+#addSectionBtn:hover {
+  background: var(--addh);
+}
+
+#basketTable {
+  table-layout: fixed;
+  background: var(--panel);
+}
+
+#basketTable th,
+#basketTable td {
+  border: 1px solid var(--border);
+  padding: 0.24rem 0.28rem;
+  box-sizing: border-box;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+#basketContainer thead th {
+  position: static;
+}
+
+#basketTable tbody tr:hover {
+  background: var(--rowHover);
+}
+
+.sort-handle {
+  cursor: move;
+  user-select: none;
+  text-align: left;
+  font-size: 1.1rem;
+  min-width: 2em;
+}
+
+.qty-input {
+  width: 48px;
+  text-align: center;
+  height: 1.6em;
+}
+
+.remove-btn {
+  color: red;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.sub-row td {
+  background: var(--alt);
+  font-size: 0.95em;
+}
+
+.sub-row .item-input {
+  min-height: 1.6em;
+}
+
+.sub-item-cell {
+  position: relative;
+  padding-left: 0;
+}
+
+.sub-row td:first-child {
+  position: relative;
+}
+
+.sub-row td:first-child::before {
+  content: "↳";
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.6;
+  font-weight: bold;
+}
+
+.sub-controls {
+  display: inline-flex;
+  gap: 0.25rem;
+  margin-right: 0.25rem;
+  vertical-align: middle;
+}
+
+.subbtn {
+  padding: 0.1rem 0.35rem;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.subbtn.active {
+  background: var(--btn);
+  color: #fff;
+  border-color: var(--btn);
+}
+
+#toast {
+  margin-left: 1rem;
+  background: var(--toast);
+  color: var(--toastfg);
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  opacity: 0;
+  transition: 0.3s;
+}
+
+#toast.show {
+  opacity: 1;
+}
+
+.import-summary-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 20000;
+  backdrop-filter: blur(1px);
+}
+
+.import-summary-card {
+  width: 100%;
+  max-width: 28rem;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background: #18181b;
+  color: #e4e4e7;
+  text-align: center;
+  box-shadow: var(--shadow-import);
+}
+
+.import-summary-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: #60a5fa;
+}
+
+.import-summary-subtitle {
+  margin: 0 0 1.25rem;
+  font-size: 1rem;
+  color: #a1a1aa;
+}
+
+.import-summary-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.25rem;
+  font-size: 1rem;
+}
+
+.import-summary-table tr {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.import-summary-table tr:last-child {
+  border-bottom: none;
+}
+
+.import-summary-table td {
+  padding: 0.55rem 0.75rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.import-summary-table td:last-child {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.import-summary-table tr:nth-child(even) {
+  background: rgba(39, 39, 42, 0.75);
+}
+
+.import-summary-divider {
+  height: 1px;
+  background: rgba(148, 163, 184, 0.35);
+  margin: 1rem 0;
+}
+
+.import-summary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.import-summary-view-btn,
+.import-summary-undo-btn {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.6rem 1.65rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.import-summary-view-btn {
+  background: #2563eb;
+  color: #fff;
+}
+
+.import-summary-view-btn:hover {
+  background: #1d4ed8;
+}
+
+.import-summary-undo-btn {
+  background: #3f3f46;
+  color: #f4f4f5;
+}
+
+.import-summary-undo-btn:hover {
+  filter: brightness(1.05);
+}
+
+.editable {
+  background: #fff;
+  border: 1px solid var(--border);
+  padding: 0.28rem 0.4rem;
+  border-radius: 6px;
+  width: 100%;
+  box-sizing: border-box;
+  display: block;
+  margin: 0;
+}
+
+.item-input {
+  display: block;
+  width: 100%;
+  min-height: 1.6em;
+  max-height: 8em;
+  resize: vertical;
+  overflow: auto;
+  white-space: pre-wrap;
+  line-height: 1.24;
+}
+
+.price-input {
+  width: 100%;
+  min-height: 1.6em;
+  max-width: none;
+  text-align: right;
+  box-sizing: border-box;
+  margin: 0;
+}
+
+.col-handle {
+  width: 36px;
+}
+
+.col-section {
+  width: 200px;
+}
+
+.col-quantity {
+  width: 120px;
+}
+
+.col-price {
+  width: 110px;
+}
+
+.col-total {
+  width: 140px;
+}
+
+.col-actions {
+  width: 50px;
+}
+
+#basketTable col#col-item,
+#basketHead col#col-item {
+  width: auto;
+}
+
+#basketHead col.col-handle,
+#basketTable col.col-handle {
+  width: 36px;
+}
+
+#basketHead col.col-section,
+#basketTable col.col-section {
+  width: 200px;
+}
+
+#basketHead col.col-quantity,
+#basketTable col.col-quantity {
+  width: 120px;
+}
+
+#basketHead col.col-price,
+#basketTable col.col-price {
+  width: 110px;
+}
+
+#basketHead col.col-total,
+#basketTable col.col-total {
+  width: 140px;
+}
+
+#basketHead col.col-actions,
+#basketTable col.col-actions {
+  width: 50px;
+}
+
+.grand-totals-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--panel);
+}
+
+.grand-totals-table th,
+.grand-totals-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-weight: 600;
+}
+
+.grand-totals-table tr:last-child th,
+.grand-totals-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.grand-totals-table th {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.grand-totals-table td {
+  font-weight: 600;
+}
+
+.grand-totals-table tr th:first-child,
+.grand-totals-table tr td:first-child {
+  border-right: 1px solid var(--border);
+}
+
+.grand-totals-table .totals-value {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.grand-totals-table .grand-totals-input {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.grand-totals-table .grand-totals-input input {
+  width: 100%;
+  padding: 0.32rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+}
+
+.grand-totals-table .grand-totals-input span {
+  opacity: 0.75;
+}
+
+.section-notes-cell {
+  padding: 0 !important;
+}
+
+.section-notes-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.45rem 0.65rem;
+}
+
+.section-notes-wrapper label {
+  font-weight: 600;
+}
+
+.section-notes-wrapper textarea {
+  width: 100%;
+  min-height: 72px;
+  padding: 0.32rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  resize: vertical;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.28;
+}
+
+.qty-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.qty-controls button {
+  padding: 0.15rem 0.4rem;
+  line-height: 1;
+}
+
+.section-cell {
+  vertical-align: middle;
+}
+
+.section-select {
+  width: 100%;
+  padding: 0.28rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel);
+  color: var(--fg);
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+
+.section-readonly {
+  display: block;
+  padding: 0.28rem 0.35rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#basketSticky {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  background: var(--panel);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--border);
+}
+
+#basketStickyHead {
+  background: var(--panel);
+}
+
+#basketStickyHead table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+#basketStickyHead thead th {
+  background: var(--header);
+  border: 1px solid var(--border);
+  padding: 0.28rem;
+  text-align: center;
+}
+
+#basketTable thead {
+  display: none;
+}
+
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.status-text {
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+}
+
+.manual-load {
+  display: none;
+  margin: 0.5rem 0;
+}
+
+/* Theme specific adjustments */
+body:not(.light) .search-hint {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.light .search-hint {
+  color: rgba(0, 0, 0, 0.55);
+}
+
+body:not(.light) .tab-source-label {
+  background: #3a3a3a;
+  color: #f5f5f5;
+  opacity: 0.85;
+}
+
+.light .tab-source-label {
+  background: var(--header);
+  color: var(--fg);
+  opacity: 0.8;
+}
+
+body:not(.light) .search-results-note {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.light .search-results-note {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+body:not(.light) summary {
+  color: #000;
+}
+
+body:not(.light) summary:hover {
+  color: #fff;
+}
+
+.light summary {
+  color: var(--fg);
+}
+
+#catalogDots button {
+  box-shadow: none;
+}
+
+body:not(.light) #catalogDots button {
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+body:not(.light) #catalogResizeHandle::after {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.subbtn {
+  color: inherit;
+}
+
+body:not(.light) .subbtn {
+  background: #fff;
+  color: #000;
+  border-color: #888;
+}
+
+body:not(.light) .subbtn:hover {
+  filter: brightness(0.95);
+}
+
+body:not(.light) .subbtn.active {
+  background: var(--btn);
+  color: #fff;
+  border-color: var(--btn);
+}
+
+body:not(.light) .import-summary-card {
+  background: #18181b;
+  color: #e4e4e7;
+  box-shadow: var(--shadow-import);
+}
+
+body:not(.light) .import-summary-title {
+  color: #60a5fa;
+}
+
+body:not(.light) .import-summary-subtitle {
+  color: #a1a1aa;
+}
+
+body:not(.light) .import-summary-table tr {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+body:not(.light) .import-summary-table tr:nth-child(even) {
+  background: rgba(39, 39, 42, 0.75);
+}
+
+body:not(.light) .import-summary-divider {
+  background: rgba(148, 163, 184, 0.35);
+}
+
+body:not(.light) .import-summary-view-btn {
+  background: #2563eb;
+}
+
+body:not(.light) .import-summary-view-btn:hover {
+  background: #1d4ed8;
+}
+
+body:not(.light) .import-summary-undo-btn {
+  background: #3f3f46;
+  color: #f4f4f5;
+}
+
+body:not(.light) .import-summary-undo-btn:hover {
+  filter: brightness(1.05);
+}
+
+body:not(.light) .section-notes-wrapper textarea {
+  background: #2c2c2c;
+  color: #fff;
+  border-color: #555;
+}
+
+body:not(.light) .section-select {
+  background: #444;
+  color: #fff;
+  border-color: #666;
+}
+
+/* Light mode overrides */
+.light .import-summary-card {
+  background: #fff;
+  color: #1f2937;
+  box-shadow: 0 25px 70px rgba(15, 23, 42, 0.35);
+}
+
+.light .import-summary-title {
+  color: #002d72;
+}
+
+.light .import-summary-subtitle {
+  color: #52525b;
+}
+
+.light .import-summary-table tr {
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.light .import-summary-table tr:nth-child(even) {
+  background: rgba(244, 244, 245, 0.7);
+}
+
+.light .import-summary-divider {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.light .import-summary-view-btn {
+  background: #0b64d0;
+}
+
+.light .import-summary-view-btn:hover {
+  background: #084fa5;
+}
+
+.light .import-summary-undo-btn {
+  background: #e4e4e7;
+  color: #27272a;
+}
+
+.light .import-summary-undo-btn:hover {
+  filter: brightness(0.95);
+}
+
+.light .section-notes-wrapper textarea {
+  background: var(--panel);
+  color: var(--fg);
+  border-color: var(--border);
+}
+
+.light .section-select {
+  background: var(--panel);
+  color: var(--fg);
+  border-color: var(--border);
+}
+
+.light .subbtn {
+  background: var(--panel);
+  color: inherit;
+  border-color: var(--border);
+}
+
+.light .subbtn:hover {
+  filter: none;
+}
+
+.light .subbtn.active {
+  background: var(--btn);
+  color: #fff;
+  border-color: var(--btn);
+}
+
+.light .status-text {
+  color: inherit;
+}
+
+.light .import-summary-card,
+.light .import-summary-view-btn,
+.light .import-summary-undo-btn {
+  transition: 0.2s ease;
+}
+

--- a/index.html
+++ b/index.html
@@ -5,198 +5,11 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.10</title>
-<style>
-:root{--bg:#f7f7f7;--fg:#333;--header:#e0e0e0;--btn:#007bff;--btnh:#0056b3;--add:#28a745;--addh:#218838;--border:#aaa;--alt:#f9f9f9;--panel:#fff;--toast:#007bff;--toastfg:#fff;--rowHover:#e9f1ff}
-.dark-mode{--bg:#222;--fg:#eee;--header:#444;--btn:#0d6efd;--btnh:#0a58ca;--add:#198754;--addh:#157347;--border:#555;--alt:#2a2a2a;--panel:#333;--toast:#0d6efd;--toastfg:#fff;--rowHover:#383838}
-body{font-family:sans-serif;margin:1rem;background:var(--bg);color:var(--fg);transition:.3s}
-h1{margin:.2rem 0}p{margin:0 0 2rem}
-#darkModeToggle{position:fixed;top:10px;right:10px;z-index:3000;background:var(--btn);color:#fff;border:none;padding:.5rem .75rem;border-radius:4px;cursor:pointer}
-#darkModeToggle:hover{background:var(--btnh)}
-#sheetTabs{border-bottom:1px solid var(--border);margin-bottom:1rem}
-#sheetTabs button{background:none;border:none;padding:.5rem 1rem;margin-right:.5rem;cursor:pointer;font-size:1rem;color:var(--fg)}
-#sheetTabs button.active{border-bottom:2px solid var(--btn);font-weight:bold}
-.search-container{margin-bottom:1rem;padding:.5rem;background:var(--panel);border:1px solid var(--border);border-radius:4px;display:flex;flex-wrap:wrap;align-items:center;gap:.5rem}
-.search-label{font-weight:bold}
-.search-control{display:flex;align-items:center;gap:.5rem;flex:1 1 220px}
-.search-input{padding:.4rem .5rem;border:1px solid var(--border);border-radius:4px;flex:1 1 auto;background:var(--panel);color:var(--fg)}
-.search-cancel{display:none;padding:.35rem .75rem;border-radius:4px;border:1px solid var(--border);background:var(--header);color:var(--fg);cursor:pointer;font-weight:600;white-space:nowrap}
-.search-cancel:hover{filter:brightness(.96)}
-.search-cancel.visible{display:inline-flex}
-.search-scope-toggle{display:inline-flex;align-items:center;gap:.35rem;margin-left:auto;font-size:.9rem;font-weight:600;opacity:.8;cursor:pointer;user-select:none;white-space:nowrap;color:var(--fg)}
-.search-scope-toggle input{width:16px;height:16px;margin:0}
-.search-hint{font-size:.8rem;color:rgba(0,0,0,.55);margin:.1rem 0 .2rem 0}
-.dark-mode .search-hint{color:rgba(255,255,255,.6)}
-.item-cell-stack{display:flex;flex-direction:column;align-items:flex-start;gap:.1rem}
-.item-cell-line{display:block}
-.tab-source-label{display:inline-flex;align-items:center;gap:.25rem;padding:.1rem .45rem;border-radius:999px;font-size:.7rem;font-weight:600;background:var(--header);color:var(--fg);opacity:.8;letter-spacing:.01em}
-.dark-mode .tab-source-label{background:#3a3a3a;color:#f5f5f5;opacity:.85}
-.search-results-note{font-size:.8rem;margin-top:.35rem;color:rgba(0,0,0,.6)}
-.dark-mode .search-results-note{color:rgba(255,255,255,.65)}
-.highlight{background:yellow}
-table{border-collapse:collapse;width:100%}
-thead th{position:sticky;top:0;background:var(--header);border:1px solid var(--border);padding:.5rem;text-align:center;z-index:2}
-tbody td{border:1px solid var(--border);padding:.5rem}
-tbody tr{background:var(--panel)}
-tbody tr:hover{background:var(--rowHover)}
-.add-button{background:var(--add);color:#fff;border:none;padding:.3rem .6rem;border-radius:4px;font-weight:bold;cursor:pointer}
-.add-button:hover{background:var(--addh)}
-.copied-cell{background:#c8e6c9!important;transition:.15s}
-details{margin-bottom:1rem}
-summary{list-style:none;cursor:pointer;display:flex;align-items:center;gap:.5rem;padding:.4rem .6rem;border-radius:4px;background:var(--header);font-weight:bold}
-summary::-webkit-details-marker{display:none}
-summary:hover{background:var(--btn);color:#fff}
-.dark-mode summary{color:#000}
-.dark-mode summary:hover{color:#fff}
-.cat-orange summary{background:#ffe9d6}.cat-orange summary:hover{background:#ffc999;color:#000}
-.cat-blue summary{background:#d8ebff}.cat-blue summary:hover{background:#add6ff;color:#000}
-.cat-brown summary{background:#f2e6d9}.cat-brown summary:hover{background:#e0cbb9;color:#000}
-.cat-red summary{background:#ffdede}.cat-red summary:hover{background:#ffb7b7;color:#000}
-.cat-yellow summary{background:#fff8d6}.cat-yellow summary:hover{background:#ffea9f;color:#000}
-#quoteBuilderMain{margin-top:1.5rem;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:0 16px 40px rgba(0,0,0,.18);padding:1rem 1.25rem 1.5rem;display:flex;flex-direction:column;gap:1rem}
-#quoteHeader{display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:.75rem}
-.quote-header-left{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}
-#quoteHeader #qbTitle{margin:0;font-size:1.55rem;font-weight:bold}
-#quoteActions{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:flex-end}
-#quoteActions button{background:var(--btn);color:#fff;border:none;padding:.4rem .75rem;border-radius:6px;cursor:pointer;font-weight:600}
-#quoteActions button:hover{background:var(--btnh)}
-#catalogWindow{position:fixed;top:64px;right:32px;width:min(1100px,90vw);height:min(65vh,80vh);background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:0 24px 80px rgba(0,0,0,.35);display:flex;flex-direction:column;z-index:10000;overflow:hidden}
-#catalogWindow.qb-full{top:0;left:0;right:0;bottom:0;width:100vw;height:100vh;border-radius:0}
-#catalogWindow.qb-docked{left:16px;right:16px;bottom:16px;width:auto;max-width:none;border-radius:12px 12px 0 0}
-#catalogWindow.qb-floating{cursor:auto}
-#catalogWindow.qb-docked #catalogTitlebar{cursor:default}
-#catalogResizeHandle{position:absolute;width:18px;height:18px;right:0;bottom:0;cursor:se-resize;display:none}
-#catalogResizeHandle::after{content:"";position:absolute;inset:4px;border-right:2px solid rgba(0,0,0,.2);border-bottom:2px solid rgba(0,0,0,.2);border-radius:2px}
-.dark-mode #catalogResizeHandle::after{border-color:rgba(255,255,255,.25)}
-#catalogWindow.qb-floating #catalogResizeHandle{display:block}
-#catalogWindow.qb-full #catalogResizeHandle,#catalogWindow.qb-docked #catalogResizeHandle{display:none}
-#catalogTitlebar{display:flex;align-items:center;justify-content:space-between;gap:.5rem;padding:.5rem .75rem;background:var(--header);border-bottom:1px solid var(--border);cursor:move;user-select:none}
-#catalogDots{display:flex;gap:.5rem}
-#catalogDots button{width:12px;height:12px;border-radius:50%;border:0;cursor:pointer}
-#catalogClose{background:#ff5f57}
-#catalogMin{background:#ffbd2e}
-#catalogZoom{background:#28c840}
-.dark-mode #catalogClose,.dark-mode #catalogMin,.dark-mode #catalogZoom{box-shadow:inset 0 0 0 1px rgba(0,0,0,.2)}
-#catalogTitle{flex:1;font-weight:bold}
-#catalogBody{flex:1;overflow:auto;scrollbar-gutter:stable both-edges;padding:0 1rem 1rem}
-#catalogDockIcon{position:fixed;left:16px;bottom:16px;display:none;border-radius:999px;padding:.5rem .8rem;background:var(--btn);color:#fff;border:none;cursor:pointer;z-index:10001}
-#catalogDockIcon:hover{background:var(--btnh)}
-.qb-modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:10002;padding:1rem}
-.qb-modal{background:var(--panel);color:var(--fg);border:1px solid var(--border);border-radius:12px;box-shadow:0 20px 60px rgba(0,0,0,.35);max-width:420px;width:100%;padding:1.25rem;display:flex;flex-direction:column;gap:1rem}
-.qb-modal h4{margin:0;font-size:1.1rem}
-.qb-modal p{margin:0;font-size:.95rem;line-height:1.4}
-.qb-modal-buttons{display:flex;gap:.5rem;justify-content:flex-end;flex-wrap:wrap}
-.qb-modal-buttons button{background:var(--btn);color:#fff;border:none;padding:.4rem .75rem;border-radius:6px;cursor:pointer}
-.qb-modal-buttons button:hover{background:var(--btnh)}
-.qb-modal-buttons .danger{background:#dc3545}
-.qb-modal-buttons .danger:hover{background:#bb2d3b}
-.qb-modal-buttons .neutral{background:var(--header);color:var(--fg)}
-.qb-modal-buttons .neutral:hover{filter:brightness(.95)}
-#basketContainer{display:flex;flex-direction:column;min-height:100%;gap:0}
-#basketContent{display:flex;flex-direction:column;gap:1rem}
-.basket-table-area{flex:1 1 auto;min-width:0}
-.grand-totals-wrapper{display:none;justify-content:flex-end;margin-top:1rem}
-
-#grandTotals{margin:0;padding:0;border:0;border-radius:8px;background:transparent;display:none;font-weight:600;width:min(320px,100%);max-width:340px}
-#sectionTabsBar{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;padding:.45rem .65rem;min-height:48px;background:var(--header);border:1px solid var(--border);border-bottom:0;border-radius:8px 8px 0 0}
-#sectionTabs{display:flex;flex-wrap:wrap;gap:.25rem}
-.section-tab{display:inline-flex;align-items:center;gap:.35rem;padding:.3rem .6rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg);cursor:pointer;transition:.2s}
-.section-tab.active{background:var(--btn);color:#fff;border-color:var(--btn)}
-.section-tab button{background:none;border:none;color:inherit;cursor:pointer;padding:0;font-size:.85rem;line-height:1}
-.section-tab button:hover{opacity:.85}
-#sectionTabs .section-name{max-width:160px;display:inline-block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-#addSectionBtn{background:var(--add);color:#fff;border:none;padding:.35rem .7rem;border-radius:6px;font-weight:bold;cursor:pointer}
-#addSectionBtn:hover{background:var(--addh)}
-#basketTable{table-layout:fixed;background:var(--panel)}
-#basketContent{background:var(--panel)}
-#basketTable th,#basketTable td{border:1px solid var(--border);padding:.24rem .28rem;box-sizing:border-box;vertical-align:middle;overflow:hidden}
-#basketContainer thead th{position:static}
-#basketTable tbody tr:hover{background:var(--rowHover)}
-.sort-handle{cursor:move;user-select:none;text-align:left;font-size:1.1rem;min-width:2em}
-.qty-input{width:48px;text-align:center;height:1.6em}
-.remove-btn{color:red;font-weight:bold;cursor:pointer}
-.sub-row td{background:var(--alt);font-size:.95em}
-.sub-row .item-input{min-height:1.6em}
-.sub-item-cell{position:relative;padding-left:0}
-.sub-row td:first-child{position:relative}
-.sub-row td:first-child::before{content:"↳";position:absolute;left:10px;top:50%;transform:translateY(-50%);opacity:.6;font-weight:bold}
-.sub-controls{display:inline-flex;gap:.25rem;margin-right:.25rem;vertical-align:middle}
-.subbtn{padding:.1rem .35rem;border:1px solid var(--border);background:var(--panel);cursor:pointer;border-radius:4px}
-.dark-mode .subbtn{background:#fff;color:#000;border-color:#888}
-.dark-mode .subbtn:hover{filter:brightness(.95)}
-.subbtn.active{background:var(--btn);color:#fff;border-color:var(--btn)}
-.dark-mode .subbtn.active{background:var(--btn);color:#fff;border-color:var(--btn)}
-#toast{margin-left:1rem;background:var(--toast);color:var(--toastfg);padding:.3rem .6rem;border-radius:4px;opacity:0;transition:.3s}
-#toast.show{opacity:1}
-.import-summary-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:1.5rem;background:rgba(0,0,0,.4);z-index:20000;backdrop-filter:blur(1px);}
-.import-summary-card{width:100%;max-width:28rem;border-radius:0.75rem;padding:1.5rem;background:#fff;color:#1f2937;text-align:center;box-shadow:0 25px 70px rgba(15,23,42,.35);}
-.dark-mode .import-summary-card{background:#18181b;color:#e4e4e7;box-shadow:0 25px 70px rgba(0,0,0,.55);}
-.import-summary-title{font-size:1.75rem;font-weight:700;margin:0 0 .5rem;color:#002d72;}
-.dark-mode .import-summary-title{color:#60a5fa;}
-.import-summary-subtitle{margin:0 0 1.25rem;font-size:1rem;color:#52525b;}
-.dark-mode .import-summary-subtitle{color:#a1a1aa;}
-.import-summary-table{width:100%;border-collapse:separate;border-spacing:0;margin-bottom:1.25rem;font-size:1rem;}
-.import-summary-table tr{border-bottom:1px solid rgba(15,23,42,.08);}
-.dark-mode .import-summary-table tr{border-bottom:1px solid rgba(148,163,184,.25);}
-.import-summary-table tr:last-child{border-bottom:none;}
-.import-summary-table td{padding:.55rem .75rem;font-weight:600;text-align:left;}
-.import-summary-table td:last-child{text-align:right;font-variant-numeric:tabular-nums;}
-.import-summary-table tr:nth-child(even){background:rgba(244,244,245,.7);}
-.dark-mode .import-summary-table tr:nth-child(even){background:rgba(39,39,42,.75);}
-.import-summary-divider{height:1px;background:rgba(15,23,42,.12);margin:1rem 0;}
-.dark-mode .import-summary-divider{background:rgba(148,163,184,.35);}
-.import-summary-actions{display:flex;flex-wrap:wrap;gap:.75rem;justify-content:center;}
-.import-summary-view-btn,.import-summary-undo-btn{border:none;border-radius:9999px;padding:.6rem 1.65rem;font-weight:600;cursor:pointer;transition:.2s ease;}
-.import-summary-view-btn{background:#0b64d0;color:#fff;}
-.import-summary-view-btn:hover{background:#084fa5;}
-.dark-mode .import-summary-view-btn{background:#2563eb;}
-.dark-mode .import-summary-view-btn:hover{background:#1d4ed8;}
-.import-summary-undo-btn{background:#e4e4e7;color:#27272a;}
-.import-summary-undo-btn:hover{filter:brightness(.95);}
-.dark-mode .import-summary-undo-btn{background:#3f3f46;color:#f4f4f5;}
-.dark-mode .import-summary-undo-btn:hover{filter:brightness(1.05);}
-.editable{background:#fff;border:1px solid var(--border);padding:.28rem .4rem;border-radius:6px;width:100%;box-sizing:border-box;display:block;margin:0}
-.item-input{display:block;width:100%;min-height:1.6em;max-height:8em;resize:vertical;overflow:auto;white-space:pre-wrap;line-height:1.24}
-.price-input{width:100%;min-height:1.6em;max-width:none;text-align:right;box-sizing:border-box;margin:0}
-#basketTable th:nth-child(1),#basketTable td:nth-child(1){width:36px}
-#basketTable th:nth-child(2),#basketTable td:nth-child(2){width:200px}
-#basketTable th:nth-child(4),#basketTable td:nth-child(4){width:120px}
-#basketTable th:nth-child(5),#basketTable td:nth-child(5){width:110px}
-#basketTable th:nth-child(6),#basketTable td:nth-child(6){width:140px}
-#basketTable th:nth-child(7),#basketTable td:nth-child(7){width:50px}
-#basketTable col#col-item,#basketHead col#col-item{width:auto}
-.grand-totals-table{width:100%;border-collapse:separate;border-spacing:0;border:1px solid var(--border);border-radius:8px;overflow:hidden;background:var(--panel)}
-.grand-totals-table th,.grand-totals-table td{padding:.4rem .5rem;border-bottom:1px solid var(--border);text-align:left;font-weight:600}
-.grand-totals-table tr:last-child th,.grand-totals-table tr:last-child td{border-bottom:0}
-.grand-totals-table th{font-weight:700;white-space:nowrap}
-.grand-totals-table td{font-weight:600}
-.grand-totals-table tr th:first-child,.grand-totals-table tr td:first-child{border-right:1px solid var(--border)}
-.grand-totals-table .totals-value{text-align:right;font-variant-numeric:tabular-nums}
-.grand-totals-table .grand-totals-input{display:flex;align-items:center;gap:.35rem}
-.grand-totals-table .grand-totals-input input{width:100%;padding:.32rem .4rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg)}
-.grand-totals-table .grand-totals-input span{opacity:.75}
-.section-notes-cell{padding:0!important}
-.section-notes-wrapper{display:flex;flex-direction:column;gap:.4rem;padding:.45rem .65rem}
-.section-notes-wrapper label{font-weight:600}
-.section-notes-wrapper textarea{width:100%;min-height:72px;padding:.32rem .4rem;border:1px solid var(--border);border-radius:6px;background:var(--panel);color:var(--fg);resize:vertical;font-family:inherit;font-size:1rem;line-height:1.28}
-.dark-mode .section-notes-wrapper textarea{background:#2c2c2c;color:#fff;border-color:#555}
-.qty-controls{display:flex;align-items:center;gap:.25rem}
-.qty-controls button{padding:.15rem .4rem;line-height:1}
-.section-cell{vertical-align:middle}
-.section-select{width:100%;padding:.28rem .35rem;border:1px solid var(--border);border-radius:4px;background:var(--panel);color:var(--fg);font-size:.9rem;box-sizing:border-box}
-.dark-mode .section-select{background:#444;color:#fff;border-color:#666}
-.section-readonly{display:block;padding:.28rem .35rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-#basketSticky{position:sticky;top:0;z-index:4;background:var(--panel);box-shadow:0 2px 4px rgba(0,0,0,.06);padding:1rem 0 0;border-top:1px solid var(--border)}
-#basketStickyHead{background:var(--panel)}
-#basketStickyHead table{width:100%;table-layout:fixed;border-collapse:collapse}
-#basketStickyHead thead th{background:var(--header);border:1px solid var(--border);padding:.28rem;text-align:center}
-#basketTable thead{display:none}
-input[type=number]::-webkit-outer-spin-button,input[type=number]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
-input[type=number]{-moz-appearance:textfield}
-</style>
+  <title>DefCost 3.0.11</title>
+<link rel="stylesheet" href="./css/style.css">
 </head>
-<body>
-        <h1>DefCost 3.0.10</h1>
+<body class="light">
+        <h1>DefCost 3.0.11</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">
@@ -210,7 +23,7 @@ input[type=number]{-moz-appearance:textfield}
       <button id="addSectionBtn" type="button">+ Section</button>
       <button id="importCsvBtn" type="button">Import CSV</button>
       <button id="exportCsvBtn" type="button">Export quote CSV</button>
-      <input id="importCsvInput" type="file" accept=".csv" style="display:none">
+      <input id="importCsvInput" class="hidden-input" type="file" accept=".csv">
     </div>
   </div>
   <div id="sectionTabsBar">
@@ -221,13 +34,13 @@ input[type=number]{-moz-appearance:textfield}
       <div id="basketStickyHead">
         <table id="basketHead">
           <colgroup>
-            <col style="width:36px">
-            <col style="width:200px">
+            <col class="col-handle">
+            <col class="col-section">
             <col id="col-item">
-            <col style="width:120px">
-            <col style="width:110px">
-            <col style="width:140px">
-            <col style="width:50px">
+            <col class="col-quantity">
+            <col class="col-price">
+            <col class="col-total">
+            <col class="col-actions">
           </colgroup>
           <thead><tr>
             <th class="sort-handle">≡</th><th>Section</th><th>Item</th><th>Quantity</th>
@@ -241,13 +54,13 @@ input[type=number]{-moz-appearance:textfield}
       <div class="basket-table-area">
       <table id="basketTable">
         <colgroup>
-          <col style="width:36px">
-          <col style="width:200px">
+          <col class="col-handle">
+          <col class="col-section">
           <col id="col-item">
-          <col style="width:120px">
-          <col style="width:110px">
-          <col style="width:140px">
-          <col style="width:50px">
+          <col class="col-quantity">
+          <col class="col-price">
+          <col class="col-total">
+          <col class="col-actions">
         </colgroup>
           <thead><tr>
             <th class="sort-handle">≡</th><th>Section</th><th>Item</th><th>Quantity</th>
@@ -274,8 +87,8 @@ input[type=number]{-moz-appearance:textfield}
   </div>
   <div id="catalogBody">
     <div id="sheetTabs"></div>
-    <div id="status" style="margin:.5rem 0;font-size:.9rem"></div>
-    <div id="manualLoad" style="display:none;margin:.5rem 0"><label class="search-label">Load workbook:</label><input type="file" id="xlsxPicker" accept=".xlsx"></div>
+    <div id="status" class="status-text"></div>
+    <div id="manualLoad" class="manual-load"><label class="search-label">Load workbook:</label><input type="file" id="xlsxPicker" accept=".xlsx"></div>
     <div id="sheetContainer"></div>
   </div>
   <div id="catalogResizeHandle" aria-hidden="true"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -674,7 +674,7 @@ hydrateFromStorage();
 var darkModeToggle=document.getElementById('darkModeToggle');
 if(darkModeToggle){
   darkModeToggle.addEventListener('click',function(){
-    document.body.classList.toggle('dark-mode');
+    document.body.classList.toggle('light');
   });
 }
 var statusEl=document.getElementById('status');var pickerWrap=document.getElementById('manualLoad');var picker=document.getElementById('xlsxPicker');


### PR DESCRIPTION
## Summary
- recreate the 3.0.10 layout in a dedicated css/style.css and hook index.html into the new class-based styling
- swap the dark-mode toggle to switch the `.light` class on `<body>` and update displayed version text to 3.0.11
- document the CSS architecture in README.md and AGENTS.md so future edits keep style references in sync

## Testing
- not run (UI refactor only)


------
https://chatgpt.com/codex/tasks/task_e_68f0c11b15688327937c4d7709874b42