### PR TITLE
Fix Sortable stale state and bump version to 3.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Defender.jpeg              # Brand image / logo
 
 ---
 
+## 3.0.12 – Quote drag ordering now respects latest state
+
+- Rebound the SortableJS handler on every render so drag-reordering always targets the current section and basket contents.
+- Prevented deleted parents (or entire sections) from reappearing when dragging after the arrays are rebuilt.
+
 ## 3.0.11 – CSS architecture introduced
 
 - Added `/css/style.css` as the single design layer for layout, spacing, and colour tokens.
@@ -108,6 +113,7 @@ Defender.jpeg              # Brand image / logo
 
 ## Versioning
 
+- **3.0.12** – Refreshed SortableJS bindings each render to keep drag-reorder operations in sync with the active section and latest basket state.
 - **3.0.11** – Technical CSS refactor: moved inline styling to `/css/style.css`, identical UI/behaviour; ensured dark-mode toggle compatibility and table alignment.
 - **3.0.10** – Removed redundant ‘Add note sub-item’ button; streamlined sub-item creation via ‘Capture catalogue adds as sub-item’ and ‘Add custom line’.
 - **3.0.9** – Added an “All Tabs” catalogue search scope with tab labels plus Enter-to-add and ⌘K / Ctrl+K catalogue shortcuts.

--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
 <meta http-equiv="Pragma" content="no-cache"/>
 <meta http-equiv="Expires" content="0"/>
 <meta charset="UTF-8">
-  <title>DefCost 3.0.11</title>
+  <title>DefCost 3.0.12</title>
 <link rel="stylesheet" href="./css/style.css">
 </head>
 <body class="light">
-        <h1>DefCost 3.0.11</h1>
+        <h1>DefCost 3.0.12</h1>
 <button id="darkModeToggle">Toggle Dark Mode</button>
 <div id="quoteBuilderMain" aria-label="Quote Builder" role="region">
   <div id="quoteHeader">

--- a/js/ui.js
+++ b/js/ui.js
@@ -762,8 +762,15 @@ window.DefCost.ui = window.DefCost.ui || {};
     updateTotals(report);
 
     var SortableCtor = state.Sortable || window.Sortable;
-    if (SortableCtor && !bBody.getAttribute('data-sortable')) {
-      SortableCtor.create(bBody, {
+    if (SortableCtor) {
+      if (state.basketSortable && typeof state.basketSortable.destroy === 'function') {
+        state.basketSortable.destroy();
+      }
+      state.basketSortable = null;
+      if (bBody && typeof bBody.removeAttribute === 'function') {
+        bBody.removeAttribute('data-sortable');
+      }
+      state.basketSortable = SortableCtor.create(bBody, {
         handle: '.sort-handle',
         draggable: 'tr.main-row',
         animation: 150,
@@ -848,7 +855,9 @@ window.DefCost.ui = window.DefCost.ui || {};
           renderBasket();
         }
       });
-      bBody.setAttribute('data-sortable', '1');
+      if (bBody && typeof bBody.setAttribute === 'function') {
+        bBody.setAttribute('data-sortable', '1');
+      }
     }
 
     persistBasket();


### PR DESCRIPTION
## Summary
- reinitialize the SortableJS binding on every render so drag-reorder always works with the latest basket and active section
- prevent deleted items or sections from returning by ensuring the drag handler reads fresh state
- update the displayed version to 3.0.12 and document the change in the README

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f70778235883278bf1641347d3b8e0